### PR TITLE
Update MatterDeviceType and mappings sort order

### DIFF
--- a/packages/common/src/entity-mapping.ts
+++ b/packages/common/src/entity-mapping.ts
@@ -109,7 +109,7 @@ export const domainToDefaultMatterTypes: Partial<
     "light_sensor",
     "pressure_sensor",
     "temperature_sensor",
-  ], 
+  ],
   switch: ["on_off_plugin_unit", "on_off_switch"],
   vacuum: ["robot_vacuum_cleaner"],
 };


### PR DESCRIPTION
Update sort order of Matter Device Types and mappings. Should make the UI list show alphabetically (currently random, see below):

<img width="546" height="466" alt="image" src="https://github.com/user-attachments/assets/14e47489-e573-4c53-a7c2-5e486da4af18" />
