### PR TITLE
Implement immediate force sync on startup

### DIFF
--- a/packages/backend/src/services/bridges/bridge.ts
+++ b/packages/backend/src/services/bridges/bridge.ts
@@ -204,6 +204,15 @@ export class Bridge {
       await this.endpointManager.startPlugins();
       this.setStatus({ code: BridgeStatus.Running });
       this.startAutoForceSyncIfEnabled();
+
+      // Force sync immediately on startup to push current HA state to controllers
+      // before they reconnect and execute any queued commands
+      if (this.dataProvider.featureFlags?.autoForceSync) {
+        this.forceSync().catch((e) => {
+          this.log.warn("Startup force sync failed:", e);
+        });
+      }
+      
       this.wireSessionDiagnostics();
       logMemoryUsage(this.log, "bridge running");
       diagnosticEventBus.emit("bridge_started", `Bridge started`, {


### PR DESCRIPTION
When the bridge is stopped (restart, update, or crash), Alexa queues any commands
issued during the downtime. When the bridge comes back online, Alexa reconnects
and executes those queued commands overriding the actual device state in Home Assistant.

On startup, the bridge should push the current Home Assistant state to all connected
controllers immediately after coming online, before accepting commands. This
would overwrite Alexa's stale cached state and prevent queued commands from executing.

The fix is intentionally non-blocking (.catch() only) so a sync failure does not
prevent the bridge from starting. It also respects the existing autoForceSync
feature flag, so it only runs for bridges where the user has enabled force sync.

The same issue likely affects Google Home and Apple Home, as they also maintain
persistent sessions and may queue commands during bridge downtime. However, this
was specifically observed and confirmed with Alexa. The 90-second AUTO_FORCE_SYNC_INTERVAL_MS constant is appropriate for periodic
syncing, but the initial startup sync needs to happen immediately to close the
race condition window.