### PR TITLE
feat(#291): add batchDispatch option to customServiceAreas for single-call multi-room integrations

### DIFF
--- a/docs-site/docs/devices/robot-vacuum.md
+++ b/docs-site/docs/devices/robot-vacuum.md
@@ -385,6 +385,60 @@ Configure `customServiceAreas` in the Entity Mapping for your vacuum. Each entry
 
 See [#177](https://github.com/RiDDiX/home-assistant-matter-hub/issues/177) for details.
 
+### Batch Dispatch Mode
+
+By default, HAMH fires **one service call per selected room** in sequence (the correct behavior for Roborock button entities, as introduced in v2.0.44). Some integrations — notably **Xiaomi Home** — instead expect all room IDs in a **single call**. Sending N sequential calls to these integrations causes N separate cleaning trips and effectively cleans only the last room.
+
+Set `batchDispatch: true` on any area definition to opt in. HAMH will fire **one combined call** using that area's `service` and `target` as the template, and inject three extra keys into `data`:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `selected_area_names` | `string[]` | Display names of every selected area |
+| `selected_area_ids_csv` | `string` | The same names joined by `","` |
+| `selected_area_data` | `Record<string, unknown>[]` | The `data` object of each selected area (empty object `{}` for areas with no data) |
+
+You only need to set `batchDispatch: true` on one area in the list; HAMH will use the first area that carries the flag as the call template. Sequential dispatch remains the default — no existing configuration is affected.
+
+#### Example: Xiaomi Home multi-room cleaning
+
+```yaml
+customServiceAreas:
+  - name: Kitchen
+    service: xiaomi_home.vacuum_clean_room_ids
+    target: vacuum.xiaomi_robot
+    batchDispatch: true
+    data:
+      room_ids: [1]
+  - name: Living Room
+    service: xiaomi_home.vacuum_clean_room_ids
+    target: vacuum.xiaomi_robot
+    batchDispatch: true
+    data:
+      room_ids: [2]
+  - name: Bedroom
+    service: xiaomi_home.vacuum_clean_room_ids
+    target: vacuum.xiaomi_robot
+    batchDispatch: true
+    data:
+      room_ids: [3]
+```
+
+When "Kitchen" and "Living Room" are selected, HAMH fires a single call with:
+
+```yaml
+action: xiaomi_home.vacuum_clean_room_ids
+target: vacuum.xiaomi_robot
+data:
+  room_ids: [1]                           # from the template area (Kitchen)
+  selected_area_names: [Kitchen, Living Room]
+  selected_area_ids_csv: "Kitchen,Living Room"
+  selected_area_data: [{ room_ids: [1] }, { room_ids: [2] }]
+```
+
+Your HA automation or script can then extract `room_ids` from `selected_area_data` and pass the full list to the integration.
+
+See [#291](https://github.com/RiDDiX/home-assistant-matter-hub/issues/291) for the original request.
+
 ---
 
 ## Identify / Locate

--- a/packages/backend/src/matter/endpoints/legacy/vacuum/behaviors/vacuum-rvc-run-mode-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/vacuum/behaviors/vacuum-rvc-run-mode-server.ts
@@ -140,6 +140,10 @@ function buildSupportedModes(
  * Build the primary action for custom service areas and queue the rest
  * for sequential dispatch. Custom areas use 1-based IDs matching
  * createCustomServiceAreaServer.
+ *
+ * When any matched area has batchDispatch === true, a single combined call
+ * is fired instead of sequential per-area calls (opt-in, for integrations
+ * like Xiaomi Home that accept all room IDs in one call).
  */
 function handleCustomServiceAreas(
   selectedAreas: number[],
@@ -155,6 +159,26 @@ function handleCustomServiceAreas(
       `Custom service areas: no match for selected IDs ${selectedAreas.join(", ")}`,
     );
     return { action: "vacuum.start" };
+  }
+
+  // Batch dispatch: one call for all selected areas, injecting combined data.
+  const batchArea = matched.find(({ area }) => area.batchDispatch === true);
+  if (batchArea) {
+    logger.info(
+      `Custom service areas (batch): single call for ${matched.length} room(s): ${matched.map(({ area }) => area.name).join(", ")}`,
+    );
+    session.pendingDispatches = [];
+    const template = batchArea.area;
+    return {
+      action: template.service,
+      target: template.target,
+      data: {
+        ...template.data,
+        selected_area_names: matched.map(({ area }) => area.name),
+        selected_area_ids_csv: matched.map(({ area }) => area.name).join(","),
+        selected_area_data: matched.map(({ area }) => area.data ?? {}),
+      },
+    };
   }
 
   logger.info(

--- a/packages/common/src/entity-mapping.ts
+++ b/packages/common/src/entity-mapping.ts
@@ -250,6 +250,15 @@ export interface CustomServiceArea {
   readonly target?: string;
   /** Optional: Additional data to pass to the service call */
   readonly data?: Record<string, unknown>;
+  /**
+   * Optional: Fire a single combined call for all selected areas instead of
+   * one call per area. Set on any area in the selection; the first matched
+   * area's service/target/data is used as the template and three extra keys
+   * are injected: selected_area_names (string[]), selected_area_ids_csv
+   * (string), and selected_area_data (Record<string, unknown>[]). Default:
+   * false (sequential dispatch, compatible with Roborock).
+   */
+  readonly batchDispatch?: boolean;
 }
 
 export interface EntityMappingRequest {


### PR DESCRIPTION
## Summary

- Adds an opt-in `batchDispatch?: boolean` field to the `CustomServiceArea` interface
- When any matched area has `batchDispatch: true`, `handleCustomServiceAreas()` fires a **single combined call** instead of N sequential calls
- Sequential dispatch remains the **default** — no existing configuration is affected (no regression to #335)
- Docs updated with a new "Batch Dispatch Mode" subsection and a Xiaomi Home YAML example

## Motivation

v2.0.44 (commit 75b6a5f, #335) correctly changed custom service area dispatch to be sequential — one call per room. This is the right behavior for Roborock button entities, where each `button.press` triggers a single-room `app_segment_clean`.

However, some integrations expect **all room IDs in a single call**. Xiaomi Home (`xiaomi_home.vacuum_clean_room_ids`) is a concrete example: sending N sequential calls causes N separate cleaning trips and effectively only cleans the last room. Issue #291 tracks this gap.

The fix is an explicit opt-in flag rather than auto-detection, keeping the default behavior intact for all existing users.

## Design

Set `batchDispatch: true` on any area definition in `customServiceAreas`. HAMH will:

1. Detect that at least one matched area has the flag
2. Use the **first flagged area's** `service`, `target`, and `data` as the call template
3. Clear `session.pendingDispatches` (no follow-up calls)
4. Inject three extra keys into `data`:
   - `selected_area_names: string[]` — display names of every selected area
   - `selected_area_ids_csv: string` — those names joined by `","`
   - `selected_area_data: Record<string, unknown>[]` — the `data` object of each selected area (`{}` for areas with no data), so HA-side scripts can extract per-area segment IDs

The existing sequential path is the `else` branch and is untouched.

## Files changed

| File | Change |
|------|--------|
| `packages/common/src/entity-mapping.ts` | Added `batchDispatch?: boolean` to `CustomServiceArea` interface with doc comment |
| `packages/backend/src/matter/endpoints/legacy/vacuum/behaviors/vacuum-rvc-run-mode-server.ts` | Added batch dispatch branch in `handleCustomServiceAreas()` |
| `docs-site/docs/devices/robot-vacuum.md` | Added "Batch Dispatch Mode" subsection under Custom Service Areas |

## Backward compatibility

This is a purely additive, opt-in change. Any `customServiceAreas` configuration without `batchDispatch: true` behaves identically to v2.0.44. TypeScript-level: `batchDispatch` is `readonly batchDispatch?: boolean`, so existing objects satisfy the updated interface without changes.

Build: `tsc --noEmit` passes with zero errors on both `@home-assistant-matter-hub/common` and `@home-assistant-matter-hub/backend` (Node 26, TypeScript 6.0.3).

## Open question for maintainer

The three injected keys (`selected_area_names`, `selected_area_ids_csv`, `selected_area_data`) are intended to give HA automations enough context to reconstruct a proper multi-room call. Is this the preferred shape? An alternative would be a single `selected_areas` array of `{ name, data }` objects. Happy to change the injected key shape before merge — the interface field itself (`batchDispatch`) would stay the same either way.

Closes #291
Does not regress #335