### PR TITLE
Fix LevelControl transitionTime patch for Matter.js 0.17

### DIFF
--- a/packages/backend/src/matter/patches/patch-level-control-tlv.test.ts
+++ b/packages/backend/src/matter/patches/patch-level-control-tlv.test.ts
@@ -1,0 +1,29 @@
+import { LevelControl } from "@matter/main/clusters/level-control";
+import { describe, expect, it } from "vitest";
+import { patchLevelControlTlv } from "./patch-level-control-tlv.js";
+
+type LevelControlField = {
+  readonly name?: string;
+  readonly propertyName?: string;
+  readonly mandatory?: boolean;
+};
+
+describe("patchLevelControlTlv", () => {
+  it("makes transitionTime optional on LevelControl move and step commands", () => {
+    patchLevelControlTlv();
+
+    expect(getTransitionTimeField("moveToLevel")?.mandatory).toBe(false);
+    expect(getTransitionTimeField("step")?.mandatory).toBe(false);
+  });
+});
+
+function getTransitionTimeField(command: "moveToLevel" | "step") {
+  const fields = LevelControl.commands[command].schema.children as
+    | LevelControlField[]
+    | undefined;
+  return fields?.find(
+    (field) =>
+      field.name === "TransitionTime" ||
+      field.propertyName === "transitionTime",
+  );
+}

--- a/packages/backend/src/matter/patches/patch-level-control-tlv.ts
+++ b/packages/backend/src/matter/patches/patch-level-control-tlv.ts
@@ -23,30 +23,95 @@ import { LevelControl } from "@matter/main/clusters/level-control";
 
 const logger = Logger.get("PatchLevelControlTlv");
 
+type LevelControlField = {
+  readonly name?: string;
+  readonly propertyName?: string;
+  optional?: boolean;
+  readonly mandatory?: boolean;
+  patch?: (definition: { conformance: "O" }) => void;
+};
+
+const optionalFieldModels = new WeakSet<object>();
+let fieldModelMandatoryGetterPatched = false;
+
 export function patchLevelControlTlv(): void {
   let patched = 0;
+  const patchErrors: string[] = [];
 
-  // Patch MoveToLevelRequest (used by moveToLevel and moveToLevelWithOnOff)
+  const markOptional = (field: LevelControlField | undefined): boolean => {
+    if (!field) {
+      return false;
+    }
+
+    try {
+      if (typeof field.patch === "function") {
+        field.patch({ conformance: "O" });
+      }
+    } catch (error) {
+      patchErrors.push(formatPatchError("patch", error));
+    }
+
+    try {
+      field.optional = true;
+    } catch (error) {
+      patchErrors.push(formatPatchError("optional", error));
+    }
+
+    try {
+      Object.defineProperty(field, "mandatory", {
+        configurable: true,
+        value: false,
+        writable: true,
+      });
+    } catch (error) {
+      patchErrors.push(formatPatchError("mandatory", error));
+    }
+
+    return field.mandatory === false || forceOptionalViaPrototype(field);
+  };
+
+  // Older Matter.js builds expose mutable fieldDefinitions on the request types.
   const moveToLevelFields = (
     LevelControl.MoveToLevelRequest as unknown as {
-      fieldDefinitions: Record<string, { id: number; optional?: boolean }>;
+      fieldDefinitions?: Record<string, LevelControlField>;
     }
   ).fieldDefinitions;
 
-  if (moveToLevelFields?.transitionTime) {
-    moveToLevelFields.transitionTime.optional = true;
+  if (markOptional(moveToLevelFields?.transitionTime)) {
     patched++;
   }
 
-  // Patch StepRequest (used by step and stepWithOnOff)
   const stepFields = (
     LevelControl.StepRequest as unknown as {
-      fieldDefinitions: Record<string, { id: number; optional?: boolean }>;
+      fieldDefinitions?: Record<string, LevelControlField>;
     }
   ).fieldDefinitions;
 
-  if (stepFields?.transitionTime) {
-    stepFields.transitionTime.optional = true;
+  if (markOptional(stepFields?.transitionTime)) {
+    patched++;
+  }
+
+  // Matter.js 0.17 exposes finalized request fields through command schemas.
+  // moveToLevelWithOnOff and stepWithOnOff share these request schemas.
+  const moveToLevelSchemaField = findTransitionTimeField(
+    LevelControl.commands.moveToLevel.schema.children as
+      | LevelControlField[]
+      | undefined,
+    1,
+  );
+
+  if (markOptional(moveToLevelSchemaField)) {
+    patched++;
+  }
+
+  const stepSchemaField = findTransitionTimeField(
+    LevelControl.commands.step.schema.children as
+      | LevelControlField[]
+      | undefined,
+    2,
+  );
+
+  if (markOptional(stepSchemaField)) {
     patched++;
   }
 
@@ -58,6 +123,75 @@ export function patchLevelControlTlv(): void {
     logger.warn(
       "Failed to patch LevelControl TLV schemas, field definitions not found. " +
         "Google Home brightness adjustment may not work.",
+      {
+        moveToLevel: describeFields(
+          LevelControl.commands.moveToLevel.schema.children as
+            | LevelControlField[]
+            | undefined,
+        ),
+        patchErrors,
+        step: describeFields(
+          LevelControl.commands.step.schema.children as
+            | LevelControlField[]
+            | undefined,
+        ),
+      },
     );
   }
+}
+
+function findTransitionTimeField(
+  fields: LevelControlField[] | undefined,
+  fallbackIndex: number,
+): LevelControlField | undefined {
+  return (
+    fields?.find(
+      (field) =>
+        field.name === "TransitionTime" ||
+        field.propertyName === "transitionTime",
+    ) ?? fields?.[fallbackIndex]
+  );
+}
+
+function forceOptionalViaPrototype(field: LevelControlField & object): boolean {
+  optionalFieldModels.add(field);
+
+  if (!fieldModelMandatoryGetterPatched) {
+    let proto = Object.getPrototypeOf(field);
+    while (proto) {
+      const descriptor = Object.getOwnPropertyDescriptor(proto, "mandatory");
+      if (descriptor?.get && descriptor.configurable) {
+        const original = descriptor.get;
+        Object.defineProperty(proto, "mandatory", {
+          configurable: true,
+          get(this: object) {
+            if (optionalFieldModels.has(this)) {
+              return false;
+            }
+            return original.call(this);
+          },
+        });
+        fieldModelMandatoryGetterPatched = true;
+        break;
+      }
+      proto = Object.getPrototypeOf(proto);
+    }
+  }
+
+  return field.mandatory === false;
+}
+
+function describeFields(fields: LevelControlField[] | undefined) {
+  return fields?.map((field, index) => ({
+    hasPatch: typeof field.patch === "function",
+    index,
+    mandatory: field.mandatory,
+    name: field.name,
+    optional: field.optional,
+    propertyName: field.propertyName,
+  }));
+}
+
+function formatPatchError(action: string, error: unknown): string {
+  return `${action}:${error instanceof Error ? error.message : String(error)}`;
 }


### PR DESCRIPTION
## Summary
- extend the LevelControl TLV runtime patch to handle Matter.js 0.17 command schema fields
- keep the existing mutable fieldDefinitions fallback for older Matter.js shapes
- add a regression test proving transitionTime becomes optional for moveToLevel and step

## Why
Google Home can omit transitionTime when dimming already-on lights. Matter.js validates the command TLV before HAMH command handlers can default the value, so non-optional transitionTime causes brightness commands to fail before application code runs.

## Validation
- `PATH=/tmp/hamh-tools:$PATH NPM_CONFIG_ENGINE_STRICT=false npm_config_engine_strict=false pnpm lint`
- `PATH=/tmp/hamh-tools:$PATH NPM_CONFIG_ENGINE_STRICT=false npm_config_engine_strict=false pnpm --filter @home-assistant-matter-hub/backend exec vitest run src/matter/patches/patch-level-control-tlv.test.ts`
- `PATH=/tmp/hamh-tools:$PATH NPM_CONFIG_ENGINE_STRICT=false npm_config_engine_strict=false pnpm run build:minimum && PATH=/tmp/hamh-tools:$PATH NPM_CONFIG_ENGINE_STRICT=false npm_config_engine_strict=false pnpm --filter @home-assistant-matter-hub/backend run build`

Note: validation was run on Node v25.9.0 with engine-strict disabled because this host does not have Node 24 installed. The repo declares Node 24.