### PR TITLE
fix: restore fan speed on Apple Home turn-on via percentSetting

### DIFF
--- a/docs-site/docs/getting-started/bridge-configuration.md
+++ b/docs-site/docs/getting-started/bridge-configuration.md
@@ -301,6 +301,7 @@ Feature flags control advanced behavior of the bridge. Configure them in the **B
 | `serverMode` | Expose device as standalone Matter device (required for Robot Vacuums with Apple Home/Alexa). Only ONE device per bridge! | `false` |
 | `productNameFromNodeLabel` | Report the node label (custom name / friendly name / entity id) as Matter `productName`. Useful for Aqara controllers that show productName as the device name. A per-entity `customProductName` still wins. | `false` |
 | `preferEntityRegistryName` | Use the entity registry name (or `original_name`) as `nodeLabel` instead of the composed `friendly_name`. HA 2026.4 prefixes `friendly_name` with the device name, breaking voice commands that relied on the short entity name. `customName` still wins. | `false` |
+| `fanRestorePercentOnTurnOn` | Restore the fan's previous speed when turned on instead of defaulting to 100%. Apple Home resets fans to 100% on every turn-on because the bridge must report 0% while the fan is off. Enable on Apple Home bridges. | `false` |
 | `vacuumOnOff` | Add OnOff cluster to vacuum endpoints. Required for Alexa discovery. In Server Mode, enabled by default unless explicitly set to `false`. In Bridge Mode, disabled by default. | (see description) |
 | `vacuumIncludeUnnamedRooms` | Include rooms without names in vacuum room selection | `false` |
 

--- a/packages/backend/src/matter/behaviors/fan-control-server.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server.ts
@@ -6,6 +6,7 @@ import {
   OnOffBehavior,
 } from "@matter/main/behaviors";
 import { FanControl } from "@matter/main/clusters";
+import { BridgeDataProvider } from "../../services/bridges/bridge-data-provider.js";
 import { applyPatchState } from "../../utils/apply-patch-state.js";
 import { FanMode } from "../../utils/converters/fan-mode.js";
 import {
@@ -383,6 +384,42 @@ export class FanControlServerBase extends FeaturedBase {
     if (!homeAssistant.isAvailable) {
       return;
     }
+
+    // When the fan transitions from off (percentCurrent=0) to on, Apple
+    // Home writes percentSetting=100 as its default because percentSetting
+    // was 0 while the fan was off (#219 requires percentSetting=0 when
+    // off, otherwise Apple Home shows "Turning off..." indefinitely).
+    // Intercept only the 100% default so explicit percentage choices (e.g.
+    // dragging the slider to 90%) are not overridden (#275).
+    const { featureFlags } = this.env.get(BridgeDataProvider);
+    if (
+      featureFlags?.fanRestorePercentOnTurnOn === true && // opt-in flag
+      this.state.percentCurrent === 0 && // fan is off
+      percentage === 100 && // controller sent the default 100%
+      this.lastNonZeroPercent > 0 // we have a previous speed to restore
+    ) {
+      if (this.lastIsAutoMode) {
+        this.syncOnOff(true);
+        homeAssistant.callAction(
+          this.state.config.setAutoMode(void 0, this.agent),
+        );
+        return;
+      }
+      if (this.lastNonZeroPercent < 100) {
+        percentage = this.lastNonZeroPercent;
+        try {
+          applyPatchState(this.state, {
+            percentSetting: percentage,
+            ...(this.features.multiSpeed && this.lastNonZeroSpeed > 0
+              ? { speedSetting: this.lastNonZeroSpeed }
+              : {}),
+          });
+        } catch {
+          // Transaction conflict — HA state update will correct the values
+        }
+      }
+    }
+
     const config = this.state.config;
     const supportsPercentage = config.supportsPercentage(
       homeAssistant.entity.state,

--- a/packages/common/src/bridge-data.ts
+++ b/packages/common/src/bridge-data.ts
@@ -99,6 +99,17 @@ interface AllBridgeFeatureFlags {
    */
   readonly alexaPreserveBrightnessOnTurnOn: boolean;
   /**
+   * Fan: Restore Percent on Turn-On. When a fan is turned off,
+   * percentSetting must be 0 (otherwise Apple Home shows "Turning off..."
+   * indefinitely). When the fan is turned back on, Apple Home writes
+   * percentSetting=100 as its default, resetting the speed. With this
+   * flag enabled, the bridge intercepts the 100% default and restores
+   * the user's previous fan speed instead.
+   * Enable on Apple Home bridges; not needed for Alexa.
+   * Default: false (disabled)
+   */
+  readonly fanRestorePercentOnTurnOn: boolean;
+  /**
    * Use HA Registry Serial Number: when set, fall back to the Home Assistant
    * device registry serial_number for the Matter serialNumber attribute when
    * no per-entity customSerialNumber is configured. Default off because

--- a/packages/common/src/controller-profiles.ts
+++ b/packages/common/src/controller-profiles.ts
@@ -27,6 +27,7 @@ export const controllerProfiles: ControllerProfile[] = [
       autoBatteryMapping: true,
       autoHumidityMapping: true,
       autoPressureMapping: true,
+      fanRestorePercentOnTurnOn: true,
     },
   },
   {

--- a/packages/common/src/schemas/bridge-config-schema.ts
+++ b/packages/common/src/schemas/bridge-config-schema.ts
@@ -287,6 +287,17 @@ const featureFlagSchema: JSONSchema7 = {
       default: false,
     },
 
+    fanRestorePercentOnTurnOn: {
+      title: "Fan: Restore Percent on Turn-On",
+      description:
+        "When a fan is turned off, the bridge sets percentSetting to 0 (required so Apple Home " +
+        "does not show 'Turning off...' indefinitely). Apple Home then defaults to 100% on the " +
+        "next turn-on. With this flag enabled, the bridge intercepts the 100% default and " +
+        "restores the fan's previous speed. Enable on Apple Home bridges.",
+      type: "boolean",
+      default: false,
+    },
+
     useHaRegistrySerial: {
       title: "Use HA Registry Serial Number",
       description:


### PR DESCRIPTION
Apple Home writes `percentSetting=100` followed by `onOff.on` as two separate Matter messages when the user taps the power button to turn on a fan.

The `percentSetting` write arrives first and triggers `targetPercentSettingChanged` > `applyPercentageAction` > `syncOnOff(true)`.

By the time `onOff.on` arrives, `onOff` is already `true`, so `applyPatchState({onOff: true})` is a no-op. The onOff$Changed event never fires and the existing `onOffChanged` restore handler from #225 never executes.

I was unsure to enable it by default so I feature gated it. We can get rid of it if wanted.