### PR TITLE
fix(fan): advertise only the fan modes the HA entity actually has

### DIFF
--- a/packages/backend/src/matter/behaviors/fan-control-server.ts
+++ b/packages/backend/src/matter/behaviors/fan-control-server.ts
@@ -7,7 +7,10 @@ import {
 } from "@matter/main/behaviors";
 import { FanControl } from "@matter/main/clusters";
 import { applyPatchState } from "../../utils/apply-patch-state.js";
-import { FanMode } from "../../utils/converters/fan-mode.js";
+import {
+  FanMode,
+  fanModeSequenceFor,
+} from "../../utils/converters/fan-mode.js";
 import {
   percentToPresetIndex,
   toAscendingSpeedPresets,
@@ -33,11 +36,14 @@ export interface FanControlRockSetting {
   rockRound?: boolean;
 }
 
+// Auto is deliberately NOT part of the shared base. Matter forbids the
+// non-auto FanModeSequence values while the AUT feature is present, so an
+// entity without an auto mode must not declare the feature at all - otherwise
+// controllers keep offering an "Auto" Home Assistant cannot honour.
 const FeaturedBase = Base.with(
   "Step",
   "MultiSpeed",
   "AirflowDirection",
-  "Auto",
   "Rocking",
   "Wind",
 ).set({
@@ -60,6 +66,9 @@ export interface FanControlServerConfig {
   // Wind mode support - returns preset mode name that maps to wind
   getWindMode: ValueGetter<"natural" | "sleep" | undefined>;
   supportsWind: ValueGetter<boolean>;
+  // Which wind modes the entity actually offers. Defaults to both when the
+  // domain does not implement it, preserving the previous behaviour.
+  getWindSupport?: ValueGetter<{ naturalWind: boolean; sleepWind: boolean }>;
 
   turnOff: ValueSetter<void>;
   turnOn: ValueSetter<number>;
@@ -100,6 +109,17 @@ export class FanControlServerBase extends FeaturedBase {
   }
 
   override async initialize() {
+    // fanModeSequence is mandatory. update() writes it through applyPatchState,
+    // which skips values equal to what state already holds, so a computed
+    // sequence matching the cluster default would never be written and
+    // matter.js then fails conformance with "you must set this attribute".
+    // The seed must match the AUT feature: Matter rejects the non-auto
+    // sequences while Auto is present, and the auto ones while it is absent.
+    if (this.state.fanModeSequence == null) {
+      this.state.fanModeSequence = this.features.auto
+        ? FanControl.FanModeSequence.OffLowMedHighAuto
+        : FanControl.FanModeSequence.OffLowMedHigh;
+    }
     // Matter.js defaults: speedMax=0, percentSetting=null, percentCurrent=0
     // speedMax=0 is invalid for MultiSpeed feature - must be >= 1 per Matter spec
     if (this.features.multiSpeed) {
@@ -215,9 +235,12 @@ export class FanControlServerBase extends FeaturedBase {
       const speedPresets = toAscendingSpeedPresets(
         presetModes.filter((m) => m.toLowerCase() !== "auto"),
       );
+      // Preset-driven fans expose exactly as many speeds as Home Assistant
+      // declares. Padding up to minSpeedMax invents speeds the entity cannot
+      // accept, which controllers then offer to the user.
       speedMax = Math.max(
-        minSpeedMax,
-        Math.min(maxSpeedMax, speedPresets.length),
+        1,
+        Math.min(maxSpeedMax, speedPresets.length || minSpeedMax),
       );
 
       // Map current preset to speed level
@@ -243,7 +266,10 @@ export class FanControlServerBase extends FeaturedBase {
     // causes Apple Home to stay on "Turning off..." indefinitely (#219).
     const isOff = percentage === 0;
 
-    const fanModeSequence = this.getFanModeSequence();
+    const supportsAuto = presetModes.some(
+      (mode) => mode.toLowerCase() === "auto",
+    );
+    const fanModeSequence = this.getFanModeSequence(speedMax, supportsAuto);
     // When the fan is off, fanMode MUST be Off regardless of preset_mode.
     // HA fans (especially Dyson) keep preset_mode="Auto" even when off;
     // setting fanMode=Auto + onOff=false causes Apple Home to show
@@ -298,6 +324,9 @@ export class FanControlServerBase extends FeaturedBase {
 
         ...(this.features.wind
           ? {
+              windSupport: config.getWindSupport
+                ? config.getWindSupport(entity.state, this.agent)
+                : { naturalWind: true, sleepWind: true },
               windSetting: this.mapWindModeToSetting(
                 config.getWindMode(entity.state, this.agent),
               ),
@@ -563,15 +592,16 @@ export class FanControlServerBase extends FeaturedBase {
     });
   }
 
-  private getFanModeSequence() {
-    if (this.features.multiSpeed) {
-      return this.features.auto
-        ? FanControl.FanModeSequence.OffLowMedHighAuto
-        : FanControl.FanModeSequence.OffLowMedHigh;
+  private getFanModeSequence(speedCount?: number, hasAuto?: boolean) {
+    // The Auto feature is only compiled in for entities that really offer it;
+    // hasAuto lets callers narrow it further from the entity's preset list.
+    const auto = hasAuto ?? this.features.auto;
+    if (!this.features.multiSpeed) {
+      return auto
+        ? FanControl.FanModeSequence.OffHighAuto
+        : FanControl.FanModeSequence.OffHigh;
     }
-    return this.features.auto
-      ? FanControl.FanModeSequence.OffHighAuto
-      : FanControl.FanModeSequence.OffHigh;
+    return fanModeSequenceFor(speedCount, auto);
   }
 
   private targetRockSettingChanged(
@@ -699,11 +729,16 @@ export namespace FanControlServerBase {
   }
 }
 
+const FanControlServerWithAuto = FanControlServerBase.with("Auto");
+
 export function FanControlServer(
   config: FanControlServerConfig,
-  defaults: { rockSupport?: FanControlRockSetting } = {},
+  defaults: { rockSupport?: FanControlRockSetting; auto?: boolean } = {},
 ) {
-  return FanControlServerBase.set({
+  // Default stays "auto supported" so existing endpoints are unchanged.
+  const base =
+    defaults.auto === false ? FanControlServerBase : FanControlServerWithAuto;
+  return base.set({
     config,
     rockSupport: defaults.rockSupport ?? { rockUpDown: true },
   });

--- a/packages/backend/src/matter/endpoints/legacy/climate/behaviors/climate-fan-control-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/climate/behaviors/climate-fan-control-server.ts
@@ -109,16 +109,25 @@ const config: FanControlServerConfig = {
   }),
 };
 
-const features: ("MultiSpeed" | "Step" | "Auto")[] = [
-  "MultiSpeed",
-  "Step",
-  "Auto",
-];
+const baseFeatures: ("MultiSpeed" | "Step")[] = ["MultiSpeed", "Step"];
+
+/** True when the climate entity declares an "auto" fan mode. */
+export function climateSupportsAutoFanMode(
+  fanModes: string[] | null | undefined,
+): boolean {
+  return (fanModes ?? []).some((mode) => mode.toLowerCase() === "auto");
+}
 
 export function ClimateFanControlServer(
   rockSupport: FanControlRockSetting | undefined,
+  supportsAutoFanMode = true,
 ) {
   return FanControlServer(config, {
     rockSupport: rockSupport ?? { rockUpDown: true },
-  }).with(...features, ...(rockSupport ? (["Rocking"] as const) : []));
+    auto: supportsAutoFanMode,
+  }).with(
+    ...baseFeatures,
+    ...(supportsAutoFanMode ? (["Auto"] as const) : []),
+    ...(rockSupport ? (["Rocking"] as const) : []),
+  );
 }

--- a/packages/backend/src/matter/endpoints/legacy/climate/index.ts
+++ b/packages/backend/src/matter/endpoints/legacy/climate/index.ts
@@ -17,6 +17,7 @@ import { DefaultPowerSourceServer } from "../../../behaviors/power-source-server
 import { ThermostatUiConfigServer } from "../../../behaviors/thermostat-ui-config-server.js";
 import {
   ClimateFanControlServer,
+  climateSupportsAutoFanMode,
   swingModesToRockSupport,
 } from "./behaviors/climate-fan-control-server.js";
 import { ClimateHumidityMeasurementServer } from "./behaviors/climate-humidity-measurement-server.js";
@@ -41,6 +42,7 @@ const ClimateDeviceType = (
   supportsOnOff: boolean,
   supportsHumidity: boolean,
   supportsFanMode: boolean,
+  supportsAutoFanMode: boolean,
   rockSupport:
     | { rockLeftRight?: boolean; rockUpDown?: boolean; rockRound?: boolean }
     | undefined,
@@ -80,7 +82,7 @@ const ClimateDeviceType = (
       HomeAssistantEntityBehavior,
       thermostatServer,
       ThermostatUiConfigServer,
-      ClimateFanControlServer(rockSupport),
+      ClimateFanControlServer(rockSupport, supportsAutoFanMode),
       ...additionalClusters,
       ...basicInfo,
     );
@@ -191,6 +193,7 @@ export function ClimateDevice(
   const supportsFanMode =
     testBit(supportedFeatures, ClimateDeviceFeature.FAN_MODE) &&
     homeAssistantEntity.mapping?.disableClimateFanControl !== true;
+  const supportsAutoFanMode = climateSupportsAutoFanMode(attributes.fan_modes);
   const supportsVerticalSwing = testBit(
     supportedFeatures,
     ClimateDeviceFeature.SWING_MODE,
@@ -269,6 +272,7 @@ export function ClimateDevice(
     supportsOnOff,
     supportsHumidity,
     supportsFanMode,
+    supportsAutoFanMode,
     rockSupport,
     hasBattery,
     {

--- a/packages/backend/src/matter/endpoints/legacy/fan/behaviors/fan-fan-control-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/fan/behaviors/fan-fan-control-server.ts
@@ -27,6 +27,27 @@ const isEnglishNatural = (m: string) => {
 };
 const isEnglishSleep = (m: string) => m.toLowerCase() === "sleep";
 
+/**
+ * Which wind modes an entity really offers, derived from its preset_modes.
+ * Matter's WindSupport is a claim about the device: advertising a mode the
+ * entity lacks makes controllers offer it, and Home Assistant then rejects
+ * the resulting fan.set_preset_mode call.
+ */
+export function windSupportFor(
+  presetModes: string[] | undefined,
+  presets: FanWindPresets,
+): { naturalWind: boolean; sleepWind: boolean } {
+  const modes = presetModes ?? [];
+  return {
+    naturalWind: modes.some(
+      (m) => isEnglishNatural(m) || !!presets.natural?.includes(m),
+    ),
+    sleepWind: modes.some(
+      (m) => isEnglishSleep(m) || !!presets.sleep?.includes(m),
+    ),
+  };
+}
+
 const fanControlConfig: FanControlServerConfig = {
   getPercentage: (state) =>
     state.state === "off" ? 0 : attributes(state).percentage,
@@ -75,6 +96,9 @@ const fanControlConfig: FanControlServerConfig = {
         !!presets.sleep?.includes(m),
     );
   },
+  // Advertise only the wind modes this entity really has (#fan-modes).
+  getWindSupport: (state, agent) =>
+    windSupportFor(attributes(state).preset_modes, windPresets(agent)),
 
   turnOff: () => ({ action: "fan.turn_off" }),
   turnOn: (percentage) => ({

--- a/packages/backend/src/matter/endpoints/legacy/fan/behaviors/fan-wind-support.test.ts
+++ b/packages/backend/src/matter/endpoints/legacy/fan/behaviors/fan-wind-support.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { windSupportFor } from "./fan-fan-control-server.js";
+
+describe("windSupportFor", () => {
+  it("claims only sleep when the entity has no natural preset", () => {
+    // A VeSync air purifier whose only preset is "sleep" was advertising
+    // naturalWind too, so controllers offered "Natural" and Home Assistant
+    // answered: Preset mode Natural is not valid, valid preset modes are: sleep
+    expect(windSupportFor(["sleep"], {})).toEqual({
+      naturalWind: false,
+      sleepWind: true,
+    });
+  });
+
+  it("claims only natural when that is the sole wind preset", () => {
+    expect(windSupportFor(["natural"], {})).toEqual({
+      naturalWind: true,
+      sleepWind: false,
+    });
+  });
+
+  it("claims both when both presets exist", () => {
+    expect(windSupportFor(["Natural", "Sleep", "Auto"], {})).toEqual({
+      naturalWind: true,
+      sleepWind: true,
+    });
+  });
+
+  it("claims nothing when the entity has no wind presets", () => {
+    expect(windSupportFor(["auto", "turbo"], {})).toEqual({
+      naturalWind: false,
+      sleepWind: false,
+    });
+    expect(windSupportFor(undefined, {})).toEqual({
+      naturalWind: false,
+      sleepWind: false,
+    });
+  });
+
+  it("honours localized preset names from the entity mapping", () => {
+    expect(
+      windSupportFor(["Viento natural"], { natural: ["Viento natural"] }),
+    ).toEqual({ naturalWind: true, sleepWind: false });
+    expect(windSupportFor(["Nocturno"], { sleep: ["Nocturno"] })).toEqual({
+      naturalWind: false,
+      sleepWind: true,
+    });
+  });
+});

--- a/packages/backend/src/utils/converters/fan-mode-sequence.test.ts
+++ b/packages/backend/src/utils/converters/fan-mode-sequence.test.ts
@@ -1,0 +1,43 @@
+import { FanControl } from "@matter/main/clusters";
+import { describe, expect, it } from "vitest";
+import { fanModeSequenceFor } from "./fan-mode.js";
+
+describe("fanModeSequenceFor", () => {
+  it("uses OffLowHigh for a two-speed entity", () => {
+    // A climate with fan_modes ["low","high"] must not advertise a Medium the
+    // entity would reject.
+    expect(fanModeSequenceFor(2, false)).toBe(
+      FanControl.FanModeSequence.OffLowHigh,
+    );
+    expect(fanModeSequenceFor(2, true)).toBe(
+      FanControl.FanModeSequence.OffLowHighAuto,
+    );
+  });
+
+  it("uses OffHigh for a single-speed entity", () => {
+    expect(fanModeSequenceFor(1, false)).toBe(
+      FanControl.FanModeSequence.OffHigh,
+    );
+    expect(fanModeSequenceFor(1, true)).toBe(
+      FanControl.FanModeSequence.OffHighAuto,
+    );
+  });
+
+  it("keeps OffLowMedHigh for three or more speeds", () => {
+    expect(fanModeSequenceFor(3, false)).toBe(
+      FanControl.FanModeSequence.OffLowMedHigh,
+    );
+    expect(fanModeSequenceFor(7, true)).toBe(
+      FanControl.FanModeSequence.OffLowMedHighAuto,
+    );
+  });
+
+  it("falls back to the full sequence when the count is unknown", () => {
+    expect(fanModeSequenceFor(undefined, false)).toBe(
+      FanControl.FanModeSequence.OffLowMedHigh,
+    );
+    expect(fanModeSequenceFor(undefined, true)).toBe(
+      FanControl.FanModeSequence.OffLowMedHighAuto,
+    );
+  });
+});

--- a/packages/backend/src/utils/converters/fan-mode.ts
+++ b/packages/backend/src/utils/converters/fan-mode.ts
@@ -103,3 +103,32 @@ function _autoSupported(sequence: FanControl.FanModeSequence): boolean {
       return false;
   }
 }
+
+/**
+ * Pick the FanModeSequence that matches how many speeds the entity actually
+ * exposes. Home Assistant entities frequently offer fewer than three speeds
+ * (a climate with fan_modes ["low","high"], a fan with a single preset), and
+ * advertising OffLowMedHigh for those makes controllers show speeds the entity
+ * will reject.
+ *
+ * @param speedCount number of selectable speeds, excluding off/auto
+ * @param auto whether the entity supports an auto mode
+ */
+export function fanModeSequenceFor(
+  speedCount: number | undefined,
+  auto: boolean,
+): FanControl.FanModeSequence {
+  if (speedCount != null && speedCount <= 1) {
+    return auto
+      ? FanControl.FanModeSequence.OffHighAuto
+      : FanControl.FanModeSequence.OffHigh;
+  }
+  if (speedCount === 2) {
+    return auto
+      ? FanControl.FanModeSequence.OffLowHighAuto
+      : FanControl.FanModeSequence.OffLowHigh;
+  }
+  return auto
+    ? FanControl.FanModeSequence.OffLowMedHighAuto
+    : FanControl.FanModeSequence.OffLowMedHigh;
+}


### PR DESCRIPTION
## Problem

Matter controllers are offered fan modes and speeds that Home Assistant does not have, and in one case the resulting command fails outright.

Real example from my install — a Cecotec AC exposed as `climate` with `fan_modes: ["low", "high"]`. Alexa showed **speeds 0/1/2/3** and modes **off / low / medium / high / on / auto / smart**. Only `low` and `high` exist.

Worse, a VeSync air purifier whose only preset is `sleep` was advertised as supporting Natural wind. Selecting it makes Home Assistant reject the call:

```
Preset mode Natural is not valid, valid preset modes are: sleep
```

## Causes

1. **`speedMax` padded to `minSpeedMax` (3)** for preset-driven entities, inventing speeds. Now uses the real preset count with a floor of 1.
2. **`getFanModeSequence()` never used `OffLowHigh`** — it only branched on `multiSpeed`/`auto`, so a two-speed entity got `OffLowMedHigh`. Extracted into a pure, unit-tested `fanModeSequenceFor(speedCount, auto)`.
3. **The `Auto` feature was compiled into every entity** via `Base.with(..., "Auto", ...)`, so `features.auto` was always true and every entity advertised an Auto mode. It is now added per entity. This also explains why the original code always picked the Auto sequences: Matter's `[!AUT].a` conformance forbids the non-auto values while the feature is present, so the feature and the sequence have to be decided together.
4. **`windSupport` was hardcoded** to `{ naturalWind: true, sleepWind: true }` on the behavior class. Now derived from the entity's `preset_modes` via an exported `windSupportFor()`, keeping the existing localized-preset mapping.

## Also fixed

`fanModeSequence` is mandatory, but `applyPatchState` skips values equal to what state already holds — so a computed sequence that happened to match the cluster default was never written, and matter.js aborted endpoint init:

```
Validating ...fanControl.state.fanModeSequence: Conformance "M":
Matter requires you to set this attribute (135)
```

It is now seeded in `initialize()`, matching the AUT feature so it stays conformant in both directions.

## Compatibility

`FanControlServer(config, defaults)` gains an optional `auto` flag that defaults to the previous behaviour, so endpoints that do not opt in are unchanged. `ClimateFanControlServer(rockSupport, supportsAutoFanMode = true)` likewise defaults to the old behaviour.

## Testing

- `pnpm vitest run` in `packages/backend`: **1053 passed, 135 files**, no failures.
- `biome check` clean, `tsc --noEmit` clean.
- 9 new tests across `fan-mode-sequence.test.ts` and `fan-wind-support.test.ts`.
- Verified on real hardware: the AC now reports `speedMax=2` with `OffLowHigh`, and Alexa shows 0/1/2 with no Medium and no Auto.

Note that `on` and `smart` remain visible in Alexa. Those are members of the Matter `FanMode` enum that controllers render regardless of `FanModeSequence`, so they are out of scope here.
