### PR TITLE
feat(water-heater): add the Matter 1.4 WaterHeaterManagement device type

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ Matter Bridge, Multi-Fabric support, Health Monitoring, Bridge Wizard, AirQualit
 | `vacuum` | Robot Vacuum Cleaner | `serverMode`, `roomEntities`, `batteryEntity`, `cleaningModeEntity`, `suctionLevelEntity`, `mopIntensityEntity`, `customServiceAreas`, `vacuumMinimalClusters`, `chargingStateEntity` ([#377](https://github.com/RiDDiX/home-assistant-matter-hub/issues/377)) |
 | `lawn_mower` | Robotic Lawn Mower (RVC-based) | reuses the robot-vacuum flags ([#301](https://github.com/RiDDiX/home-assistant-matter-hub/issues/301)) |
 | `humidifier` | Humidifier/Dehumidifier | |
-| `water_heater` | Thermostat (Heating) | |
+| `water_heater` | Thermostat (Heating) | Optional `water_heater_management` override exposes the Matter 1.4 Water Heater (0x050F) with WaterHeaterManagement Boost/CancelBoost, WaterHeaterMode and a heating Thermostat |
 | `automation`, `script`, `scene` | On/Off Switch | The per-entity "On/Off Switch" override now produces a real `0x0100` On/Off Light (controllers render a switch), needs a one-time re-pair, and no longer carries power/energy fields ([#380](https://github.com/RiDDiX/home-assistant-matter-hub/issues/380)) |
 
 > 📖 See [Supported Device Types Documentation](https://riddix.github.io/home-assistant-matter-hub/supported-device-types) for details

--- a/docs-site/docs/guides/controller-compatibility.md
+++ b/docs-site/docs/guides/controller-compatibility.md
@@ -42,6 +42,7 @@ Rows flagged with a footnote number link to the vendor source that establishes t
 | `valve` | WaterValve | ❌ [⁵](#sources) | ❌ [¹](#sources) | ❌ [²](#sources) | ✅ [⁴](#sources) | ❓ |
 | `vacuum` | RoboticVacuumCleaner | ✅ [³](#sources)[⁵](#sources) | ✅ [¹](#sources) | ✅* [²](#sources) | ✅ [⁴](#sources) | ❓ |
 | `water_heater` | Thermostat | ✅ | ✅ | ✅ | ✅ [⁴](#sources) | ❓ |
+| `water_heater` (override) | WaterHeater (Matter 1.4) | ❌ | ❌ | ❓ | ❓ | ❓ |
 | `alarm_control_panel` | ModeSelect | ❌ [⁵](#sources) | ❓ | ❌** | ❓ | ❓ |
 | `select` | ModeSelect | ❌ [⁵](#sources) | ❌*** | ❌** | ❓ | ❓ |
 | `event` | GenericSwitch | ✅ [⁵](#sources) | ❓ | ✅ [²](#sources) | ❓ | ❓ |
@@ -51,6 +52,16 @@ Rows flagged with a footnote number link to the vendor source that establishes t
 
 :::note EnergyEvse is opt-in and bridge-sensitive
 EnergyEvse (0x050C) is only used when you set the Matter device type to "EV Charger (EVSE)" by hand. Home Assistant and Aqara Home render it; SmartThings announced support but it is unconfirmed here. A bridged EVSE has been reported to break Alexa device recognition, so keep it off any bridge that Alexa pairs with. See [mapping blueprints](./mapping-blueprints.md#ev-charger-evse).
+:::
+
+:::note The Matter 1.4 water heater is opt-in
+By default a `water_heater` entity is exposed as a plain heating Thermostat, which every controller
+renders. Setting the Matter device type to "Water Heater with Boost (Matter 1.4)" by hand swaps the
+endpoint to WaterHeater (0x050F) with the WaterHeaterManagement (cluster revision 2), WaterHeaterMode
+and Thermostat clusters, which adds the Boost and CancelBoost commands for energy-management
+controllers. No
+mainstream controller renders 0x050F today, and changing the type on an already-paired entity
+requires re-pairing it. See [mapping blueprints](./mapping-blueprints.md).
 :::
 
 :::note Leak and freeze detectors are opt-in

--- a/docs-site/docs/supported-device-types.md
+++ b/docs-site/docs/supported-device-types.md
@@ -597,6 +597,7 @@ You can override the default device type mapping per entity using the Entity Map
 - AirQualitySensor, BatteryStorage, TVOCSensor
 - WaterValve, Pump
 - WaterHeater
+- WaterHeaterManagement — "Water Heater with Boost (Matter 1.4)", the 0x050F device type with the WaterHeaterManagement (Boost / CancelBoost), WaterHeaterMode and heating Thermostat clusters. Opt-in: it is aimed at energy-management controllers, no mainstream controller renders 0x050F yet, and switching an already-paired entity to it needs a re-pair
 - Dishwasher
 - GenericSwitch
 - SmokeCO Alarm, Water Leak Detector, Water Freeze Detector

--- a/packages/backend/src/matter/endpoints/legacy/create-legacy-endpoint-type.ts
+++ b/packages/backend/src/matter/endpoints/legacy/create-legacy-endpoint-type.ts
@@ -75,6 +75,7 @@ import { MountedOnOffControlType } from "./switch/mounted-on-off-control.js";
 import { VacuumDevice } from "./vacuum/index.js";
 import { ValveDevice } from "./valve/index.js";
 import { WaterHeaterDevice } from "./water-heater/index.js";
+import { WaterHeaterManagementDevice } from "./water-heater/water-heater-management-device.js";
 import { WeatherDevice } from "./weather/index.js";
 
 const legacyLogger = Logger.get("LegacyEndpointType");
@@ -359,6 +360,7 @@ const matterDeviceTypeFactories: Partial<
   pump: PumpEndpoint,
   rain_sensor: (ha) => RainSensorType.set({ homeAssistantEntity: ha }),
   water_heater: WaterHeaterDevice,
+  water_heater_management: WaterHeaterManagementDevice,
   generic_switch: EventDevice,
   smoke_co_alarm: (ha) => SmokeAlarmType.set({ homeAssistantEntity: ha }),
   water_freeze_detector: (ha) =>

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/behaviors/water-heater-management-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/behaviors/water-heater-management-server.ts
@@ -1,0 +1,360 @@
+import type {
+  HomeAssistantEntityInformation,
+  WaterHeaterDeviceAttributes,
+} from "@home-assistant-matter-hub/common";
+import { WaterHeaterOperationMode } from "@home-assistant-matter-hub/common";
+import { Logger } from "@matter/general";
+import {
+  WaterHeaterManagementServer as Base,
+  ThermostatBehavior,
+} from "@matter/main/behaviors";
+import { WaterHeaterManagement } from "@matter/main/clusters";
+import { StatusCode, StatusResponseError } from "@matter/main/types";
+import type { HomeAssistantAction } from "../../../../../services/home-assistant/home-assistant-actions.js";
+import { HomeAssistantConfig } from "../../../../../services/home-assistant/home-assistant-config.js";
+import { applyPatchState } from "../../../../../utils/apply-patch-state.js";
+import { Temperature } from "../../../../../utils/converters/temperature.js";
+import { HomeAssistantEntityBehavior } from "../../../../behaviors/home-assistant-entity-behavior.js";
+import {
+  activeHeatSource,
+  type WaterHeaterModeMapping,
+} from "../water-heater-modes.js";
+
+const logger = Logger.get("WaterHeaterManagementServer");
+
+/** setTimeout truncates delays beyond ~24.8 days to 32 bit and fires at once. */
+const MAX_TIMER_MS = 2_147_483_647;
+
+/**
+ * What a running Boost has to undo when it ends.
+ *
+ * matter.js runs every command on a throwaway proxy instance, so instance
+ * fields do not survive to a later timer callback. The session is keyed on the
+ * persistent Endpoint object instead (the EVSE charge-window precedent).
+ */
+interface BoostSession {
+  timer?: ReturnType<typeof setTimeout>;
+  /** HA operation mode the entity was in before the boost. */
+  previousOperationMode?: string;
+  /** Target temperature in HA units to restore, when boost overrode it. */
+  restoreTemperature?: number;
+  /** Boost target in HA units, used for the OneShot cut-off. */
+  boostTarget?: number;
+  oneShot: boolean;
+}
+
+const boostSessions = new WeakMap<object, BoostSession>();
+
+function clearBoostTimer(endpoint: object) {
+  const session = boostSessions.get(endpoint);
+  if (session?.timer) {
+    clearTimeout(session.timer);
+    session.timer = undefined;
+  }
+}
+
+function numeric(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const parsed = typeof value === "string" ? Number.parseFloat(value) : value;
+  return typeof parsed === "number" && !Number.isNaN(parsed)
+    ? parsed
+    : undefined;
+}
+
+/**
+ * WaterHeaterManagement (0x0094, Matter 1.4) on top of a Home Assistant
+ * water_heater entity.
+ *
+ * Boost switches the entity to its fastest heating operation mode (high_demand,
+ * else performance, else plain turn_on) for the requested duration and restores
+ * the previous mode and setpoint when the boost ends — whether that is through
+ * CancelBoost, the duration expiring, the OneShot cut-off, or the user changing
+ * the mode in Home Assistant.
+ *
+ * The EnergyManagement and TankPercent features stay off: Home Assistant
+ * exposes neither tank volume nor a hot-water level, so TankVolume,
+ * EstimatedHeatRequired and TankPercentage could only be invented.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: used by the factory below
+class WaterHeaterManagementServerBase extends Base {
+  declare state: WaterHeaterManagementServerBase.State;
+
+  override async initialize() {
+    await super.initialize();
+    const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
+    this.update(homeAssistant.entity);
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
+  }
+
+  override async [Symbol.asyncDispose]() {
+    clearBoostTimer(this.endpoint);
+    await super[Symbol.asyncDispose]();
+  }
+
+  private get attributes(): WaterHeaterDeviceAttributes {
+    return this.agent.get(HomeAssistantEntityBehavior).entity.state
+      .attributes as WaterHeaterDeviceAttributes;
+  }
+
+  private get unit(): string {
+    return this.agent.env.get(HomeAssistantConfig).unitSystem.temperature;
+  }
+
+  private update(entity: HomeAssistantEntityInformation) {
+    if (!entity.state?.attributes) {
+      return;
+    }
+    const attributes = entity.state.attributes as WaterHeaterDeviceAttributes;
+    const isOff =
+      entity.state.state === WaterHeaterOperationMode.off ||
+      attributes.operation_mode === WaterHeaterOperationMode.off;
+
+    const session = boostSessions.get(this.endpoint);
+    const boosting =
+      this.state.boostState === WaterHeaterManagement.BoostState.Active;
+
+    if (boosting && session) {
+      // The boost ends when Home Assistant leaves the boost mode behind our
+      // back, and — for a OneShot boost — once the water is up to temperature.
+      const boostMode = this.state.mapping.boostOperationMode;
+      const leftBoostMode =
+        isOff || (boostMode != null && attributes.operation_mode !== boostMode);
+      const current = numeric(attributes.current_temperature);
+      const target = session.boostTarget ?? numeric(attributes.temperature);
+      const reachedTarget =
+        session.oneShot &&
+        current != null &&
+        target != null &&
+        current >= target;
+
+      if (leftBoostMode || reachedTarget) {
+        this.endBoost({ restore: reachedTarget });
+        return;
+      }
+    }
+
+    const heating =
+      !isOff &&
+      (() => {
+        const current = numeric(attributes.current_temperature);
+        const target = numeric(attributes.temperature);
+        if (current == null || target == null) {
+          // Nothing to compare, a running heater is assumed to be heating.
+          return true;
+        }
+        return current < target;
+      })();
+
+    // HeaterTypes has quality F (fixed) and is seeded at endpoint construction,
+    // so only HeatDemand is patched here.
+    applyPatchState(this.state, {
+      heatDemand: heating ? activeHeatSource(attributes) : {},
+    });
+  }
+
+  override boost(request: WaterHeaterManagement.BoostRequest) {
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    const attributes = this.attributes;
+    const info = request.boostInfo;
+
+    // A fresh Boost supersedes a running one, but must not overwrite the
+    // pre-boost mode we still owe a restore to.
+    const running = boostSessions.get(this.endpoint);
+    clearBoostTimer(this.endpoint);
+
+    // TargetPercentage and TargetReheat are conformant only under the
+    // TankPercent feature, which this server does not support. The spec and the
+    // reference implementation both reject the command rather than ignore the
+    // fields (connectedhomeip water-heater-management-server.cpp).
+    if (info.targetPercentage != null || info.targetReheat != null) {
+      throw new StatusResponseError(
+        "TargetPercentage and TargetReheat require the TankPercent feature",
+        StatusCode.InvalidCommand,
+      );
+    }
+
+    const session: BoostSession = {
+      oneShot: info.oneShot === true,
+      previousOperationMode:
+        running?.previousOperationMode ??
+        attributes.operation_mode ??
+        undefined,
+      restoreTemperature: running?.restoreTemperature,
+    };
+
+    const actions: HomeAssistantAction[] = [];
+    const boostMode = this.state.mapping.boostOperationMode;
+    if (boostMode != null) {
+      actions.push({
+        action: "water_heater.set_operation_mode",
+        data: { operation_mode: boostMode },
+      });
+    } else {
+      // No fast mode offered, the best a Boost can do is make sure it runs.
+      actions.push({ action: "water_heater.turn_on", data: {} });
+    }
+
+    if (info.temporarySetpoint != null) {
+      this.assertSetpointInRange(info.temporarySetpoint);
+      const temperature = Temperature.celsius(info.temporarySetpoint / 100);
+      if (temperature) {
+        const value = temperature.toUnit(this.unit);
+        session.boostTarget = value;
+        session.restoreTemperature =
+          running?.restoreTemperature ?? numeric(attributes.temperature);
+        actions.push({
+          action: "water_heater.set_temperature",
+          data: { temperature: value },
+        });
+      }
+    } else {
+      session.boostTarget = numeric(attributes.temperature);
+    }
+
+    boostSessions.set(this.endpoint, session);
+    for (const action of actions) {
+      homeAssistant.callAction(action);
+    }
+
+    applyPatchState(this.state, {
+      boostState: WaterHeaterManagement.BoostState.Active,
+      heatDemand: activeHeatSource(attributes),
+    });
+    this.events.boostStarted.emit({ boostInfo: info }, this.context);
+
+    this.armBoostTimer(info.duration);
+  }
+
+  /**
+   * TemporarySetpoint shall be within MinHeatSetpointLimit and
+   * MaxHeatSetpointLimit of the thermostat cluster, inclusive. Those limits are
+   * what this endpoint advertises from the entity's min_temp / max_temp, so a
+   * value outside them would be a temperature the water heater never offered.
+   */
+  private assertSetpointInRange(temporarySetpoint: number) {
+    let min: number | undefined;
+    let max: number | undefined;
+    try {
+      // The Heating feature is mandatory on this device type, but the base
+      // behavior's state type does not carry the feature-gated attributes.
+      const thermostat = this.agent.get(ThermostatBehavior).state as {
+        minHeatSetpointLimit?: number;
+        maxHeatSetpointLimit?: number;
+      };
+      min = thermostat.minHeatSetpointLimit;
+      max = thermostat.maxHeatSetpointLimit;
+    } catch {
+      // No thermostat on this endpoint, nothing to validate against.
+      return;
+    }
+    if (
+      (min != null && temporarySetpoint < min) ||
+      (max != null && temporarySetpoint > max)
+    ) {
+      throw new StatusResponseError(
+        `TemporarySetpoint ${temporarySetpoint} outside the heat setpoint limits ${min}..${max}`,
+        StatusCode.ConstraintError,
+      );
+    }
+  }
+
+  override cancelBoost() {
+    if (
+      this.state.boostState === WaterHeaterManagement.BoostState.Inactive &&
+      !boostSessions.has(this.endpoint)
+    ) {
+      return;
+    }
+    this.endBoost({ restore: true });
+  }
+
+  /**
+   * Stop the boost and put the entity back the way it was.
+   *
+   * restore: false skips the Home Assistant calls, for the case where HA itself
+   * already moved the entity off the boost mode and re-applying the old mode
+   * would fight the user.
+   */
+  private endBoost(options: { restore: boolean }) {
+    clearBoostTimer(this.endpoint);
+    const session = boostSessions.get(this.endpoint);
+    boostSessions.delete(this.endpoint);
+
+    if (options.restore && session) {
+      const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+      if (session.restoreTemperature != null) {
+        homeAssistant.callAction({
+          action: "water_heater.set_temperature",
+          data: { temperature: session.restoreTemperature },
+        });
+      }
+      if (session.previousOperationMode != null) {
+        homeAssistant.callAction({
+          action: "water_heater.set_operation_mode",
+          data: { operation_mode: session.previousOperationMode },
+        });
+      }
+    }
+
+    applyPatchState(this.state, {
+      boostState: WaterHeaterManagement.BoostState.Inactive,
+    });
+    this.events.boostEnded.emit(undefined, this.context);
+  }
+
+  /** Auto-cancel once the requested boost duration is up. */
+  private armBoostTimer(durationSeconds: number) {
+    const delay = durationSeconds * 1000;
+    if (!Number.isFinite(delay) || delay <= 0 || delay > MAX_TIMER_MS) {
+      logger.debug(
+        `Boost duration ${durationSeconds}s outside the timer range, boost stays active until CancelBoost`,
+      );
+      return;
+    }
+    const endpoint = this.endpoint;
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          // Only the current owner may fire, a fresh Boost replaces the timer.
+          if (boostSessions.get(endpoint)?.timer !== timer) return;
+          await endpoint.act((agent) => {
+            agent
+              .get(WaterHeaterManagementServerBase)
+              .endBoost({ restore: true });
+          });
+        } catch (error) {
+          logger.debug(
+            `Boost expiry failed (endpoint may be closing): ${error}`,
+          );
+        }
+      })();
+    }, delay);
+    // A safety net must not keep the event loop alive on its own.
+    (timer as { unref?: () => void }).unref?.();
+    const session = boostSessions.get(endpoint);
+    if (session) {
+      session.timer = timer;
+    }
+  }
+}
+
+namespace WaterHeaterManagementServerBase {
+  export class State extends Base.State {
+    mapping!: WaterHeaterModeMapping;
+  }
+}
+
+export function WaterHeaterManagementServer(
+  mapping: WaterHeaterModeMapping,
+  sources: WaterHeaterManagement.WaterHeaterHeatSource,
+) {
+  return WaterHeaterManagementServerBase.set({
+    mapping,
+    // heaterTypes, heatDemand and boostState are mandatory and have no
+    // defaults, an unseeded endpoint fails to mount. heaterTypes additionally
+    // has quality F, so it is set here once and never patched at runtime.
+    heaterTypes: sources,
+    heatDemand: {},
+    boostState: WaterHeaterManagement.BoostState.Inactive,
+  });
+}

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/behaviors/water-heater-mode-server.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/behaviors/water-heater-mode-server.ts
@@ -1,0 +1,97 @@
+import type {
+  HomeAssistantEntityInformation,
+  WaterHeaterDeviceAttributes,
+} from "@home-assistant-matter-hub/common";
+import { WaterHeaterModeServer as Base } from "@matter/main/behaviors";
+import { ModeUtils } from "@matter/main/behaviors/mode-base";
+import { ModeBase } from "@matter/main/clusters/mode-base";
+import { applyPatchState } from "../../../../../utils/apply-patch-state.js";
+import { HomeAssistantEntityBehavior } from "../../../../behaviors/home-assistant-entity-behavior.js";
+import {
+  currentMode,
+  OFF_MODE,
+  type WaterHeaterModeMapping,
+} from "../water-heater-modes.js";
+
+/**
+ * WaterHeaterMode (0x009E) driven by the water_heater entity's operation modes.
+ *
+ * supportedModes has to be seeded before initialize() runs: the matter.js base
+ * server asserts there that exactly one Off-tagged and one Manual-tagged mode
+ * exist, and it validates every currentMode write against the list.
+ */
+// biome-ignore lint/correctness/noUnusedVariables: used by the factory below
+class WaterHeaterModeServerBase extends Base {
+  declare state: WaterHeaterModeServerBase.State;
+
+  override async initialize() {
+    await super.initialize();
+    const homeAssistant = await this.agent.load(HomeAssistantEntityBehavior);
+    this.update(homeAssistant.entity);
+    // offline: true runs the reactor in its own transaction, otherwise writes
+    // land after the parent transaction finalized and never reach subscribers.
+    this.reactTo(homeAssistant.onChange, this.update, { offline: true });
+  }
+
+  private update(entity: HomeAssistantEntityInformation) {
+    if (!entity.state?.attributes) {
+      return;
+    }
+    applyPatchState(this.state, {
+      currentMode: currentMode(
+        this.state.mapping,
+        entity.state.state,
+        entity.state.attributes as WaterHeaterDeviceAttributes,
+      ),
+    });
+  }
+
+  override changeToMode(
+    request: ModeBase.ChangeToModeRequest,
+  ): ModeBase.ChangeToModeResponse {
+    // Same validation the matter.js base server runs, inlined because its
+    // changeToMode is typed MaybePromise and cannot be awaited from a
+    // synchronous override.
+    const response = ModeUtils.assertModeChange(
+      this.state.supportedModes,
+      this.state.currentMode,
+      request.newMode,
+    );
+    if (response.status !== ModeBase.ModeChangeStatus.Success) {
+      return response;
+    }
+    this.state.currentMode = request.newMode;
+
+    const homeAssistant = this.agent.get(HomeAssistantEntityBehavior);
+    const operationMode = this.state.mapping.haOperationModes[request.newMode];
+
+    if (operationMode != null) {
+      homeAssistant.callAction({
+        action: "water_heater.set_operation_mode",
+        data: { operation_mode: operationMode },
+      });
+    } else if (request.newMode === OFF_MODE) {
+      homeAssistant.callAction({ action: "water_heater.turn_off", data: {} });
+    } else {
+      homeAssistant.callAction({ action: "water_heater.turn_on", data: {} });
+    }
+    return response;
+  }
+}
+
+namespace WaterHeaterModeServerBase {
+  export class State extends Base.State {
+    mapping!: WaterHeaterModeMapping;
+  }
+}
+
+export function WaterHeaterModeServer(
+  mapping: WaterHeaterModeMapping,
+  initialMode: number,
+) {
+  return WaterHeaterModeServerBase.set({
+    mapping,
+    supportedModes: mapping.supportedModes,
+    currentMode: initialMode,
+  });
+}

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/index.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/index.ts
@@ -22,7 +22,7 @@ const WaterHeaterDeviceType = ThermostatDevice.with(
  * Convert HA temperature to Matter temperature (0.01°C units).
  * Returns undefined if value is null/undefined/invalid.
  */
-function toMatterTemp(
+export function toMatterTemp(
   value: string | number | null | undefined,
 ): number | undefined {
   if (value == null) return undefined;

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-management-bringup.test.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-management-bringup.test.ts
@@ -1,0 +1,391 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HomeAssistantEntityInformation } from "@home-assistant-matter-hub/common";
+import { Environment, VariableService } from "@matter/general";
+import { Endpoint, VendorId } from "@matter/main";
+import { ServerNode } from "@matter/main/node";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BridgeDataProvider } from "../../../../services/bridges/bridge-data-provider.js";
+import { EntityStateProvider } from "../../../../services/bridges/entity-state-provider.js";
+import {
+  type HomeAssistantAction,
+  HomeAssistantActions,
+} from "../../../../services/home-assistant/home-assistant-actions.js";
+import { HomeAssistantConfig } from "../../../../services/home-assistant/home-assistant-config.js";
+import { AggregatorEndpoint } from "../../aggregator-endpoint.js";
+import { createLegacyEndpointType } from "../create-legacy-endpoint-type.js";
+
+// Matter 1.4 Water Heater (0x050F): WaterHeaterManagement + WaterHeaterMode +
+// a heating-only Thermostat on one endpoint. The mandatory clusters brick the
+// endpoint on mount unless they are seeded, and WaterHeaterMode additionally
+// asserts its Off/Manual tag invariants during initialize(), so this brings the
+// real endpoint online through createLegacyEndpointType.
+
+const WATER_HEATER = 0x050f; // 1295
+const BOOST_COMMAND = 0x00;
+const CANCEL_BOOST_COMMAND = 0x01;
+
+const OFF_MODE = 0;
+const ECO_MODE = 1;
+const HEAT_PUMP_MODE = 4;
+const HIGH_DEMAND_MODE = 5;
+
+let dir: string;
+let env: Environment;
+let counter = 0;
+let server: ServerNode | undefined;
+let calls: HomeAssistantAction[];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "hamh-water-heater-"));
+  calls = [];
+  env = new Environment("test", Environment.default);
+  env.get(VariableService).set("storage.path", dir);
+  env.set(HomeAssistantActions, {
+    call(action: HomeAssistantAction) {
+      calls.push(action);
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any);
+  env.set(
+    BridgeDataProvider,
+    new BridgeDataProvider({
+      id: "b",
+      name: "b",
+      port: 0,
+      filter: { include: [], exclude: [], includeMode: "any" },
+      basicInformation: {
+        vendorId: 0xfff1,
+        vendorName: "t",
+        productName: "t",
+        productLabel: "t",
+        hardwareVersion: 1,
+        softwareVersion: 1,
+        // biome-ignore lint/suspicious/noExplicitAny: test fixture
+      } as any,
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+    } as any),
+  );
+  env.set(HomeAssistantConfig, {
+    unitSystem: { temperature: "°C" },
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any);
+  env.set(EntityStateProvider, {
+    getState: () => undefined,
+    getNumericState: () => null,
+    getBatteryPercent: () => null,
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any);
+});
+
+afterEach(async () => {
+  await server?.close().catch(() => {});
+  server = undefined;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function waterHeater(
+  state: string,
+  attributes: Record<string, unknown>,
+): HomeAssistantEntityInformation {
+  const entityId = "water_heater.boiler";
+  return {
+    entity_id: entityId,
+    state: {
+      entity_id: entityId,
+      state,
+      attributes: { friendly_name: "Boiler", ...attributes },
+      context: { id: "c" },
+      last_changed: "2026-01-01T00:00:00",
+      last_updated: "2026-01-01T00:00:00",
+      // biome-ignore lint/suspicious/noExplicitAny: test fixture
+    } as any,
+  };
+}
+
+async function bringUp(entity: HomeAssistantEntityInformation) {
+  const type = createLegacyEndpointType(entity, {
+    entityId: entity.entity_id,
+    matterDeviceType: "water_heater_management",
+  });
+  if (!type) {
+    throw new Error("no endpoint type");
+  }
+  server = await ServerNode.create({
+    // biome-ignore lint/suspicious/noExplicitAny: env valid at runtime
+    environment: env as any,
+    id: `water-heater-node-${counter++}`,
+    network: { port: 0 },
+    commissioning: { passcode: 20202021, discriminator: 3840 },
+    basicInformation: { vendorId: VendorId(0xfff1), productId: 0x8000 },
+  });
+  const aggregator = new AggregatorEndpoint("aggregator");
+  await server.add(aggregator);
+  const endpoint = new Endpoint(type, { id: "water-heater" });
+  await aggregator.add(endpoint);
+  return endpoint;
+}
+
+interface Snapshot {
+  deviceTypes: number[];
+  acceptedCommands: number[];
+  boostState: number;
+  heaterTypes: Record<string, boolean>;
+  heatDemand: Record<string, boolean>;
+  currentMode: number;
+  supportedModes: { mode: number; label: string; tags: number[] }[];
+  heatingSetpoint: number;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: reads cluster state off the agent
+async function snapshot(endpoint: Endpoint<any>): Promise<Snapshot> {
+  let result: Snapshot | undefined;
+  await endpoint.act((agent) => {
+    // biome-ignore lint/suspicious/noExplicitAny: read cluster state
+    const a = agent as any;
+    result = {
+      deviceTypes: (
+        a.descriptor.state.deviceTypeList as { deviceType: number }[]
+      ).map((d) => Number(d.deviceType)),
+      acceptedCommands: (
+        a.waterHeaterManagement.state.acceptedCommandList as number[]
+      ).map((c) => Number(c)),
+      boostState: Number(a.waterHeaterManagement.state.boostState),
+      heaterTypes: { ...a.waterHeaterManagement.state.heaterTypes },
+      heatDemand: { ...a.waterHeaterManagement.state.heatDemand },
+      currentMode: Number(a.waterHeaterMode.state.currentMode),
+      supportedModes: (
+        a.waterHeaterMode.state.supportedModes as {
+          mode: number;
+          label: string;
+          modeTags: { value: number }[];
+        }[]
+      ).map((m) => ({
+        mode: Number(m.mode),
+        label: m.label,
+        tags: m.modeTags.map((t) => Number(t.value)),
+      })),
+      heatingSetpoint: Number(a.thermostat.state.occupiedHeatingSetpoint),
+    };
+  });
+  if (!result) {
+    throw new Error("snapshot not taken");
+  }
+  return result;
+}
+
+const OFF_TAG = 0x4000;
+const MANUAL_TAG = 0x4001;
+const LOW_ENERGY_TAG = 4;
+const MAX_TAG = 7;
+
+const FULL_HEATER = {
+  operation_list: ["eco", "heat_pump", "high_demand", "off"],
+  operation_mode: "eco",
+  current_temperature: 45,
+  temperature: 60,
+  min_temp: 30,
+  max_temp: 75,
+};
+
+describe("Matter 1.4 water heater bring-up", () => {
+  it("mounts as WaterHeater (0x050F) with Boost and CancelBoost", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    const state = await snapshot(endpoint);
+
+    expect(state.deviceTypes).toContain(WATER_HEATER);
+    expect(state.acceptedCommands).toContain(BOOST_COMMAND);
+    expect(state.acceptedCommands).toContain(CANCEL_BOOST_COMMAND);
+    // Seeded, otherwise the mandatory attributes brick the endpoint on mount.
+    expect(state.boostState).toBe(0); // Inactive
+  });
+
+  it("maps operation_list onto Off, Manual and descriptive modes", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    const state = await snapshot(endpoint);
+
+    const byMode = Object.fromEntries(
+      state.supportedModes.map((m) => [m.mode, m]),
+    );
+    expect(byMode[OFF_MODE].tags).toEqual([OFF_TAG]);
+    // heat_pump outranks eco for the Manual tag: Manual means "heat to the
+    // thermostat setpoint", which is a heat source, not an energy profile.
+    expect(byMode[HEAT_PUMP_MODE].tags).toEqual([MANUAL_TAG]);
+    expect(byMode[ECO_MODE].tags).toEqual([LOW_ENERGY_TAG]);
+    expect(byMode[HIGH_DEMAND_MODE].tags).toEqual([MAX_TAG]);
+    // Exactly one Off and one Manual, the matter.js server asserts this.
+    expect(
+      state.supportedModes.filter((m) => m.tags.includes(MANUAL_TAG)),
+    ).toHaveLength(1);
+    expect(state.currentMode).toBe(ECO_MODE);
+  });
+
+  it("keeps the thermostat setpoint and the water heater temperature range", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    const state = await snapshot(endpoint);
+    expect(state.heatingSetpoint).toBe(6000); // 60°C
+  });
+
+  it("reports heat sources and demand from the operation modes", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    const state = await snapshot(endpoint);
+
+    expect(state.heaterTypes.heatPump).toBe(true);
+    // 45°C current below the 60°C target, so the heater is calling for heat.
+    expect(Object.values(state.heatDemand)).toContain(true);
+  });
+
+  it("stands up an entity without operation modes on a synthetic On mode", async () => {
+    const endpoint = await bringUp(
+      waterHeater("on", { current_temperature: 50, temperature: 55 }),
+    );
+    const state = await snapshot(endpoint);
+
+    expect(state.supportedModes.map((m) => m.tags)).toEqual([
+      [OFF_TAG],
+      [MANUAL_TAG],
+    ]);
+    expect(state.heaterTypes.other).toBe(true);
+  });
+});
+
+describe("Matter 1.4 water heater boost", () => {
+  it("switches to high_demand and reports BoostState Active", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterManagement.boost({
+        boostInfo: { duration: 3600 },
+      });
+    });
+
+    expect(calls).toContainEqual({
+      action: "water_heater.set_operation_mode",
+      data: { operation_mode: "high_demand" },
+    });
+    expect((await snapshot(endpoint)).boostState).toBe(1); // Active
+  });
+
+  it("applies a temporary setpoint and restores it on CancelBoost", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterManagement.boost({
+        boostInfo: { duration: 1800, temporarySetpoint: 7000 },
+      });
+    });
+    expect(calls).toContainEqual({
+      action: "water_heater.set_temperature",
+      data: { temperature: 70 },
+    });
+
+    calls.length = 0;
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterManagement.cancelBoost();
+    });
+
+    // The pre-boost setpoint and operation mode both come back.
+    expect(calls).toContainEqual({
+      action: "water_heater.set_temperature",
+      data: { temperature: 60 },
+    });
+    expect(calls).toContainEqual({
+      action: "water_heater.set_operation_mode",
+      data: { operation_mode: "eco" },
+    });
+    expect((await snapshot(endpoint)).boostState).toBe(0); // Inactive
+  });
+
+  it("rejects TargetPercentage without the TankPercent feature", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await expect(async () => {
+      await endpoint.act((agent) => {
+        // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+        (agent as any).waterHeaterManagement.boost({
+          boostInfo: { duration: 600, targetPercentage: 80 },
+        });
+      });
+    }).rejects.toThrow(/TankPercent/);
+
+    // Rejected commands must not touch Home Assistant.
+    expect(calls).toEqual([]);
+    expect((await snapshot(endpoint)).boostState).toBe(0); // Inactive
+  });
+
+  it("rejects a TemporarySetpoint outside the heat setpoint limits", async () => {
+    // FULL_HEATER advertises 30..75 °C, so 90 °C is out of range.
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await expect(async () => {
+      await endpoint.act((agent) => {
+        // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+        (agent as any).waterHeaterManagement.boost({
+          boostInfo: { duration: 600, temporarySetpoint: 9000 },
+        });
+      });
+    }).rejects.toThrow(/TemporarySetpoint/);
+
+    expect((await snapshot(endpoint)).boostState).toBe(0); // Inactive
+  });
+
+  it("falls back to turn_on when no fast operation mode is offered", async () => {
+    const endpoint = await bringUp(
+      waterHeater("on", { current_temperature: 50, temperature: 55 }),
+    );
+    calls.length = 0;
+
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterManagement.boost({
+        boostInfo: { duration: 600 },
+      });
+    });
+
+    expect(calls).toContainEqual({
+      action: "water_heater.turn_on",
+      data: {},
+    });
+    expect((await snapshot(endpoint)).boostState).toBe(1); // Active
+  });
+});
+
+describe("Matter 1.4 water heater mode changes", () => {
+  it("drives the HA operation mode from ChangeToMode", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterMode.changeToMode({ newMode: HEAT_PUMP_MODE });
+    });
+
+    expect(calls).toContainEqual({
+      action: "water_heater.set_operation_mode",
+      data: { operation_mode: "heat_pump" },
+    });
+  });
+
+  it("turns the heater off through the Off mode", async () => {
+    const endpoint = await bringUp(waterHeater("eco", FULL_HEATER));
+    calls.length = 0;
+
+    await endpoint.act((agent) => {
+      // biome-ignore lint/suspicious/noExplicitAny: invoke the cluster command
+      (agent as any).waterHeaterMode.changeToMode({ newMode: OFF_MODE });
+    });
+
+    expect(calls).toContainEqual({
+      action: "water_heater.set_operation_mode",
+      data: { operation_mode: "off" },
+    });
+  });
+});

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-management-device.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-management-device.ts
@@ -1,0 +1,74 @@
+import type { WaterHeaterDeviceAttributes } from "@home-assistant-matter-hub/common";
+import { Logger } from "@matter/general";
+import type { EndpointType } from "@matter/main";
+import { WaterHeaterDevice as MatterWaterHeaterDevice } from "@matter/main/devices";
+import { BasicInformationServer } from "../../../behaviors/basic-information-server.js";
+import { HomeAssistantEntityBehavior } from "../../../behaviors/home-assistant-entity-behavior.js";
+import { IdentifyServer } from "../../../behaviors/identify-server.js";
+import { ThermostatUiConfigServer } from "../../../behaviors/thermostat-ui-config-server.js";
+import { WaterHeaterManagementServer } from "./behaviors/water-heater-management-server.js";
+import { WaterHeaterModeServer } from "./behaviors/water-heater-mode-server.js";
+import { WaterHeaterThermostatServer } from "./behaviors/water-heater-thermostat-server.js";
+import { toMatterTemp } from "./index.js";
+import {
+  buildModeMapping,
+  currentMode,
+  heaterTypes,
+} from "./water-heater-modes.js";
+
+const logger = Logger.get("WaterHeaterManagementDevice");
+
+/**
+ * Matter 1.4 Water Heater (0x050F): WaterHeaterManagement with Boost /
+ * CancelBoost, WaterHeaterMode and a heating-only Thermostat on one endpoint.
+ *
+ * Opt-in through the `water_heater_management` device type override. The
+ * default for the water_heater domain stays the plain Thermostat device,
+ * because swapping the clusters on an endpoint breaks controllers that have
+ * already paired it, and no mainstream controller renders 0x050F yet.
+ */
+export function WaterHeaterManagementDevice(
+  homeAssistantEntity: HomeAssistantEntityBehavior.State,
+): EndpointType {
+  const entityState = homeAssistantEntity.entity.state;
+  const attributes = entityState.attributes as WaterHeaterDeviceAttributes;
+
+  const modeMapping = buildModeMapping(attributes);
+  const initialMode = currentMode(modeMapping, entityState.state, attributes);
+
+  logger.debug(
+    `Creating Matter 1.4 water heater for ${homeAssistantEntity.entity.entity_id}, ` +
+      `modes=[${modeMapping.supportedModes.map((m) => `${m.mode}:${m.label}`).join(", ")}], ` +
+      `boostMode=${modeMapping.boostOperationMode ?? "none"}`,
+  );
+
+  const minLimit = toMatterTemp(attributes.min_temp) ?? 0;
+  const maxLimit = toMatterTemp(attributes.max_temp) ?? 12000;
+  const currentTemp =
+    toMatterTemp(attributes.current_temperature) ??
+    toMatterTemp(attributes.temperature) ??
+    2100;
+  const heatingSetpoint = toMatterTemp(attributes.temperature) ?? 10000;
+
+  return MatterWaterHeaterDevice.with(
+    BasicInformationServer,
+    IdentifyServer,
+    HomeAssistantEntityBehavior,
+    WaterHeaterThermostatServer,
+    ThermostatUiConfigServer,
+    WaterHeaterManagementServer(modeMapping, heaterTypes(attributes)),
+    WaterHeaterModeServer(modeMapping, initialMode),
+  ).set({
+    homeAssistantEntity,
+    // matter.js validates the thermostat limits before initialize() runs, so
+    // they have to ride along on the endpoint (#145).
+    thermostat: {
+      localTemperature: currentTemp,
+      occupiedHeatingSetpoint: heatingSetpoint,
+      minHeatSetpointLimit: minLimit,
+      maxHeatSetpointLimit: maxLimit,
+      absMinHeatSetpointLimit: minLimit,
+      absMaxHeatSetpointLimit: maxLimit,
+    },
+  });
+}

--- a/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-modes.ts
+++ b/packages/backend/src/matter/endpoints/legacy/water-heater/water-heater-modes.ts
@@ -1,0 +1,244 @@
+import {
+  type WaterHeaterDeviceAttributes,
+  WaterHeaterOperationMode,
+} from "@home-assistant-matter-hub/common";
+import {
+  type WaterHeaterManagement,
+  WaterHeaterMode,
+} from "@matter/main/clusters";
+
+/**
+ * Matter mode values for the Home Assistant operation modes we know about.
+ *
+ * These are wire values a controller caches after commissioning, so they are
+ * fixed per HA operation mode and must never be renumbered. Modes reported by
+ * an integration that are not in this list get ids from UNKNOWN_MODE_BASE
+ * upwards, in operation_list order.
+ */
+const KNOWN_MODE_VALUES: Record<string, number> = {
+  [WaterHeaterOperationMode.off]: 0,
+  [WaterHeaterOperationMode.eco]: 1,
+  [WaterHeaterOperationMode.electric]: 2,
+  [WaterHeaterOperationMode.gas]: 3,
+  [WaterHeaterOperationMode.heat_pump]: 4,
+  [WaterHeaterOperationMode.high_demand]: 5,
+  [WaterHeaterOperationMode.performance]: 6,
+};
+
+/** The Off mode is always present, whether or not HA lists an "off" mode. */
+export const OFF_MODE = 0;
+
+/**
+ * Mode used when the entity exposes no operation modes at all. The Matter
+ * WaterHeaterMode cluster still requires a Manual-tagged mode, so we synthesize
+ * one that maps onto water_heater.turn_on.
+ */
+const SYNTHETIC_MANUAL_MODE = 7;
+
+const UNKNOWN_MODE_BASE = 8;
+
+/**
+ * Which HA operation mode gets the Manual tag, in order of preference. Manual
+ * means "heat to the thermostat setpoint", so a plain heat-source mode is a
+ * better fit than eco or a boost mode. Exactly one mode may carry this tag.
+ */
+const MANUAL_PREFERENCE: string[] = [
+  WaterHeaterOperationMode.heat_pump,
+  WaterHeaterOperationMode.electric,
+  WaterHeaterOperationMode.gas,
+  WaterHeaterOperationMode.eco,
+  WaterHeaterOperationMode.performance,
+  WaterHeaterOperationMode.high_demand,
+];
+
+/**
+ * Tags for the modes that do not carry Manual or Off. Off, Manual and Timed
+ * must each appear at most once and alone, the remaining tags are unrestricted.
+ */
+const MODE_TAGS: Record<string, WaterHeaterMode.ModeTag> = {
+  [WaterHeaterOperationMode.eco]: WaterHeaterMode.ModeTag.LowEnergy,
+  [WaterHeaterOperationMode.high_demand]: WaterHeaterMode.ModeTag.Max,
+  [WaterHeaterOperationMode.performance]: WaterHeaterMode.ModeTag.Quick,
+  [WaterHeaterOperationMode.heat_pump]: WaterHeaterMode.ModeTag.LowEnergy,
+  [WaterHeaterOperationMode.electric]: WaterHeaterMode.ModeTag.Auto,
+  [WaterHeaterOperationMode.gas]: WaterHeaterMode.ModeTag.Auto,
+};
+
+/** Heat source each HA operation mode calls on, where it is identifiable. */
+const HEAT_SOURCES: Record<
+  string,
+  keyof WaterHeaterManagement.WaterHeaterHeatSource
+> = {
+  [WaterHeaterOperationMode.electric]: "immersionElement1",
+  [WaterHeaterOperationMode.gas]: "boiler",
+  [WaterHeaterOperationMode.heat_pump]: "heatPump",
+};
+
+/**
+ * The HA operation mode a Boost command switches to, in order of preference.
+ * Both mean "heat as fast as you can" in Home Assistant terms.
+ */
+const BOOST_PREFERENCE: string[] = [
+  WaterHeaterOperationMode.high_demand,
+  WaterHeaterOperationMode.performance,
+];
+
+export interface WaterHeaterModeMapping {
+  readonly supportedModes: WaterHeaterMode.ModeOption[];
+  /**
+   * Matter mode value to HA operation mode. A null value means the mode has no
+   * HA operation mode behind it and is driven through water_heater.turn_on /
+   * water_heater.turn_off instead.
+   */
+  readonly haOperationModes: Readonly<Record<number, string | null>>;
+  /** Mode value carrying the Manual tag. */
+  readonly manualMode: number;
+  /** HA operation mode a Boost switches to, undefined when none is offered. */
+  readonly boostOperationMode?: string;
+}
+
+function humanize(operationMode: string): string {
+  const label = operationMode
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+  // ModeOptionStruct.Label is capped at 64 characters by the spec.
+  return label.slice(0, 64);
+}
+
+/**
+ * Build the WaterHeaterMode supported modes from an entity's operation_list.
+ *
+ * The cluster server asserts its invariants during initialize(), before any HA
+ * state arrives, so the result has to be seeded onto the behavior at endpoint
+ * construction time rather than patched in later.
+ */
+export function buildModeMapping(
+  attributes: WaterHeaterDeviceAttributes,
+): WaterHeaterModeMapping {
+  const operationList = (attributes.operation_list ?? []).filter(
+    (mode): mode is string => typeof mode === "string" && mode.length > 0,
+  );
+  const heatingModes = operationList.filter(
+    (mode) => mode !== WaterHeaterOperationMode.off,
+  );
+
+  const haOperationModes: Record<number, string | null> = {
+    // Off is synthesized when HA does not list it, and then falls back to
+    // water_heater.turn_off.
+    [OFF_MODE]: operationList.includes(WaterHeaterOperationMode.off)
+      ? WaterHeaterOperationMode.off
+      : null,
+  };
+
+  const supportedModes: WaterHeaterMode.ModeOption[] = [
+    {
+      label: "Off",
+      mode: OFF_MODE,
+      modeTags: [{ value: WaterHeaterMode.ModeTag.Off }],
+    },
+  ];
+
+  const manualOperationMode = MANUAL_PREFERENCE.find((mode) =>
+    heatingModes.includes(mode),
+  );
+  const manualMode =
+    manualOperationMode != null
+      ? KNOWN_MODE_VALUES[manualOperationMode]
+      : SYNTHETIC_MANUAL_MODE;
+
+  if (manualOperationMode == null) {
+    // No operation modes at all (or off-only): a Manual mode is still
+    // mandatory, so drive it through water_heater.turn_on.
+    supportedModes.push({
+      label: "On",
+      mode: SYNTHETIC_MANUAL_MODE,
+      modeTags: [{ value: WaterHeaterMode.ModeTag.Manual }],
+    });
+    haOperationModes[SYNTHETIC_MANUAL_MODE] = null;
+  }
+
+  let nextUnknownMode = UNKNOWN_MODE_BASE;
+  for (const operationMode of heatingModes) {
+    const mode = KNOWN_MODE_VALUES[operationMode] ?? nextUnknownMode++;
+    if (haOperationModes[mode] !== undefined) {
+      // Duplicate entry in operation_list, keep the first.
+      continue;
+    }
+    haOperationModes[mode] = operationMode;
+    supportedModes.push({
+      label: humanize(operationMode),
+      mode,
+      modeTags: [
+        {
+          value:
+            operationMode === manualOperationMode
+              ? WaterHeaterMode.ModeTag.Manual
+              : (MODE_TAGS[operationMode] ?? WaterHeaterMode.ModeTag.Auto),
+        },
+      ],
+    });
+  }
+
+  return {
+    supportedModes,
+    haOperationModes,
+    manualMode,
+    boostOperationMode: BOOST_PREFERENCE.find((mode) =>
+      heatingModes.includes(mode),
+    ),
+  };
+}
+
+/** Matter mode value currently reported by the entity. */
+export function currentMode(
+  mapping: WaterHeaterModeMapping,
+  entityState: string,
+  attributes: WaterHeaterDeviceAttributes,
+): number {
+  if (entityState === WaterHeaterOperationMode.off) {
+    return OFF_MODE;
+  }
+  const operationMode = attributes.operation_mode;
+  if (operationMode === WaterHeaterOperationMode.off) {
+    return OFF_MODE;
+  }
+  if (operationMode != null) {
+    for (const [mode, haMode] of Object.entries(mapping.haOperationModes)) {
+      if (haMode === operationMode) {
+        return Number(mode);
+      }
+    }
+  }
+  return mapping.manualMode;
+}
+
+/** Heat sources the appliance can call on, derived from its operation modes. */
+export function heaterTypes(
+  attributes: WaterHeaterDeviceAttributes,
+): WaterHeaterManagement.WaterHeaterHeatSource {
+  const sources: WaterHeaterManagement.WaterHeaterHeatSource = {};
+  for (const operationMode of attributes.operation_list ?? []) {
+    const source = operationMode != null ? HEAT_SOURCES[operationMode] : null;
+    if (source) {
+      sources[source] = true;
+    }
+  }
+  if (Object.keys(sources).length === 0) {
+    // HA never says how the water is heated for eco/performance-only heaters.
+    sources.other = true;
+  }
+  return sources;
+}
+
+/** Heat source behind the operation mode the entity is currently in. */
+export function activeHeatSource(
+  attributes: WaterHeaterDeviceAttributes,
+): WaterHeaterManagement.WaterHeaterHeatSource {
+  const operationMode = attributes.operation_mode;
+  const source = operationMode != null ? HEAT_SOURCES[operationMode] : null;
+  if (source) {
+    return { [source]: true };
+  }
+  return heaterTypes(attributes);
+}

--- a/packages/common/src/entity-mapping.ts
+++ b/packages/common/src/entity-mapping.ts
@@ -46,6 +46,7 @@ export type MatterDeviceType =
   | "thermostat"
   | "tvoc_sensor"
   | "water_heater"
+  | "water_heater_management"
   | "water_freeze_detector"
   | "water_leak_detector"
   | "water_valve"
@@ -538,6 +539,7 @@ export const matterDeviceTypeLabels: Record<MatterDeviceType, string> = {
   thermostat: "Thermostat",
   tvoc_sensor: "TVOC / VOC Index Sensor",
   water_heater: "Water Heater",
+  water_heater_management: "Water Heater with Boost (Matter 1.4)",
   water_freeze_detector: "Water Freeze Detector",
   water_leak_detector: "Water Leak Detector",
   water_valve: "Water Valve",
@@ -794,6 +796,13 @@ export const matterDeviceTypeControllerSupport: Record<
     note: "Apple added leak sensors in iOS 18.4.",
   },
   water_heater: { apple: "no", google: "no", alexa: "unknown", aqara: "yes" },
+  water_heater_management: {
+    apple: "no",
+    google: "no",
+    alexa: "unknown",
+    aqara: "unknown",
+    note: "Matter 1.4 Water Heater (0x050F) with WaterHeaterManagement Boost/CancelBoost. Energy-management controllers only, no mainstream controller renders it yet.",
+  },
   generic_switch: {
     apple: "partial",
     google: "no",
@@ -902,5 +911,5 @@ export const domainToDefaultMatterTypes: Partial<
   ],
   vacuum: ["robot_vacuum_cleaner"],
   valve: ["water_valve", "on_off_plugin_unit"],
-  water_heater: ["water_heater", "thermostat"],
+  water_heater: ["water_heater", "water_heater_management", "thermostat"],
 };


### PR DESCRIPTION
## What

Adds the Matter **1.4** WaterHeater device type (`0x050F`) as the opt-in `water_heater_management` device-type override. The endpoint composes three clusters:

- **WaterHeaterManagement** (`0x0094`, cluster revision 2) — `Boost` / `CancelBoost`, `BoostState`, `HeaterTypes`, `HeatDemand`, and the `BoostStarted` / `BoostEnded` events
- **WaterHeaterMode** (`0x009E`, revision 1) — built from the entity's `operation_list`
- the existing heating-only **Thermostat** server, unchanged

## Why

A `water_heater` entity is currently exposed as a plain heating Thermostat. That gives controllers a setpoint but no way to ask for a fast reheat, which is what the WaterHeaterManagement cluster exists for.

## How Boost maps onto Home Assistant

- Boost switches the entity to its fastest operation mode — `high_demand`, else `performance`, else a plain `water_heater.turn_on`
- `TemporarySetpoint` becomes a `water_heater.set_temperature` call
- The boost ends on `CancelBoost`, on the requested duration expiring, on the `OneShot` cut-off once the water reaches the target, or when Home Assistant leaves the boost mode by itself. The previous operation mode and setpoint are restored

## Spec conformance

- `TargetPercentage` / `TargetReheat` are conformant only under the TankPercent feature, which this server does not support, so a Boost carrying either is rejected with `INVALID_COMMAND` rather than silently ignored — the behaviour of the reference implementation in `connectedhomeip`
- `TemporarySetpoint` must fall within `MinHeatSetpointLimit`..`MaxHeatSetpointLimit`; outside that range the command is rejected with `CONSTRAINT_ERROR`, so the bridge never asks Home Assistant for a temperature it never advertised
- `HeaterTypes` has quality **F** (fixed), so it is seeded once at endpoint construction and never patched from entity updates. Only `HeatDemand` tracks the live state
- EnergyManagement and TankPercent stay off: Home Assistant exposes neither a tank volume nor a hot-water level, so `TankVolume`, `EstimatedHeatRequired` and `TankPercentage` could only be invented

## Opt-in, not the new default

The `water_heater` domain still maps to a Thermostat. Endpoint composition is what a controller caches at commissioning, so changing it under the domain would break every water heater already paired through the bridge. On top of that, no mainstream controller renders `0x050F` — the device type targets energy-management controllers.

Switching an already-paired entity to the override therefore needs a one-time re-pair. This is documented in the controller-compatibility guide.

## Frozen wire values

`WaterHeaterMode` asserts during `initialize()` that exactly one Off-tagged and one Manual-tagged mode exists and that neither tag shares its entry, so `supportedModes` is seeded onto the endpoint at construction time rather than patched in later. The mode values are fixed per Home Assistant operation mode (`off=0`, `eco=1`, `electric=2`, `gas=3`, `heat_pump=4`, `high_demand=5`, `performance=6`; unknown modes from 8 upwards in `operation_list` order) because controllers cache them — renumbering later would break existing pairings.

## Verification

- `pnpm run lint`, `pnpm run build` and `pnpm test` all pass (1056 backend, 124 common, 59 frontend, 2 app)
- 12 bring-up tests cover the mount, the advertised device type and command list, the mode tags and the Off/Manual invariants, Boost with a temporary setpoint plus the restore on `CancelBoost`, both rejection paths, the `turn_on` fallback when no fast mode is offered, and `ChangeToMode`
- **Not verified:** behaviour against a real controller. Passing tests do not prove a pairing survives — nothing mainstream renders `0x050F`, so exercising Boost end to end needs an energy-management controller or `chip-tool`.

