### PR TITLE
Preserve explicit actions during debounce

### DIFF
--- a/packages/backend/src/services/home-assistant/home-assistant-actions.test.ts
+++ b/packages/backend/src/services/home-assistant/home-assistant-actions.test.ts
@@ -17,7 +17,12 @@ function fakeLogger(): LoggerService {
   } as unknown as LoggerService;
 }
 
-function makeActions(sendMessagePromise: () => Promise<unknown>) {
+function makeActions(
+  sendMessagePromise: (message: {
+    type: string;
+    [key: string]: unknown;
+  }) => Promise<unknown>,
+) {
   const client = {
     haRunning: true,
     messageTimeoutMs: 50,
@@ -100,5 +105,34 @@ describe("HomeAssistantActions availability (#446)", () => {
     await vi.waitFor(() =>
       expect(actions.isTargetBlocked("light.flaky")).toBe(false),
     );
+  });
+});
+
+describe("HomeAssistantActions debounce", () => {
+  it("keeps explicit commands separate while coalescing adjustments", async () => {
+    const serviceData: unknown[] = [];
+    const sendMessagePromise = async (message: {
+      type: string;
+      [key: string]: unknown;
+    }) => {
+      if (message.type === "call_service") {
+        serviceData.push(message.service_data);
+      }
+      return {};
+    };
+    const { actions } = makeActions(sendMessagePromise);
+
+    actions.call(
+      { action: "light.turn_on", data: { brightness: 100 } },
+      "light.lamp",
+    );
+    actions.call({ action: "light.turn_on" }, "light.lamp");
+    actions.call(
+      { action: "light.turn_on", data: { brightness: 200 } },
+      "light.lamp",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(serviceData).toEqual([{ brightness: 200 }, {}]);
   });
 });

--- a/packages/backend/src/services/home-assistant/home-assistant-actions.ts
+++ b/packages/backend/src/services/home-assistant/home-assistant-actions.ts
@@ -146,7 +146,8 @@ export class HomeAssistantActions extends Service {
     // are debounced independently instead of being merged incorrectly.
     const target =
       action.target === false ? entityId : (action.target ?? entityId);
-    const key = `${target}-${action.action}`;
+    const intent = Object.keys(action.data ?? {}).length ? "adjust" : "command";
+    const key = `${target}-${action.action}-${intent}`;
     this.debounceContext.get(key, 100)({ ...action, entityId });
   }
 


### PR DESCRIPTION
## Summary

- keep data-free service commands separate from data-bearing updates during the 100 ms debounce window
- continue coalescing rapid data-bearing updates to their latest combined data
- cover the observed brightness, explicit on, brightness sequence

## Root cause

Matter On/Off maps to a data-free light.turn_on call, while Level Control maps to light.turn_on with brightness data. The current debounce key contains only target and action, so those semantically different calls share one buffer and Object.assign absorbs the explicit On into the brightness update before Home Assistant receives either command.

In the observed Flic sequence the hub receives:

1. light.turn_on with brightness
2. plain light.turn_on
3. light.turn_on with a newer brightness

Before this change Home Assistant sees one brightness-bearing call. After this change it sees the coalesced latest brightness call and the distinct plain On call. This preserves the explicit command while retaining slider/rotary coalescing.

A downstream MQTT light cannot recover the intent because the plain call has already disappeared before Home Assistant invokes the entity.

## Validation

- targeted HomeAssistantActions tests: 5 passed
- backend TypeScript check: passed
- Biome check for changed files: passed
- full backend suite: 1,439 passed; the only 2 failures are existing patch-verification tests that cannot resolve the optional @matter/node package in this checkout