### PR TITLE
feat(security): mirror Home Assistant alarm panels

### DIFF
--- a/docs-site/docs/guides/plugin-system.md
+++ b/docs-site/docs/guides/plugin-system.md
@@ -160,7 +160,7 @@ Some device types need a live matter.js `EndpointType` (custom clusters and comm
 
 Plugins run on standard bridges only. A bridge with Server Mode enabled hosts no plugins at all, including the built-in camera; the Plugins page lists it with a note saying so. If every bridge you have is in Server Mode, create a standard bridge and put the camera there. Apple Home does not render Matter cameras; as of 2026 SmartThings is the only controller that does.
 
-A built-in plugin registers no devices until it is actually configured: the camera waits for camera entity ids, the security plugin for at least one trigger list. Until then nothing appears on your controllers, and once you save a real config the devices mount without a bridge restart. Disabling a plugin removes its mounted devices right away and the choice is stored per bridge, so a disabled plugin stays disabled across restarts until you enable it again.
+A built-in plugin registers no devices until it is actually configured: the camera waits for camera entity ids, the security plugin for at least one trigger list or a source alarm panel. Until then nothing appears on your controllers, and once you save a real config the devices mount without a bridge restart. Disabling a plugin removes its mounted devices right away and the choice is stored per bridge, so a disabled plugin stays disabled across restarts until you enable it again.
 
 **Camera** exposes a Home Assistant camera as a Matter Camera (0x0142). It implements the Matter `WebRtcTransportProvider` flow and bridges HA's WebRTC. To configure it, open the Plugins page and click the camera plugin (or its gear icon). A settings dialog opens; fill in the cameras and save:
 
@@ -189,6 +189,7 @@ Every entity field is a comma-separated list, deduplicated on parse. Alert lists
 | `exitDelaySeconds` | Delay before an armed mode takes effect. Default 60, 0 disables. |
 | `entryDelaySeconds` | Delay for perimeter (door/window/garage door/opening) sensors while armed. Default 60, 0 disables. |
 | `triggerTimeSeconds` | How long the alarm stays tripped before returning to the state it was tripped from. Default 120, 0 keeps it tripped until disarm. |
+| `sourceAlarmPanel` | Optional existing `alarm_control_panel.*` entity to mirror instead of running an independent alarm. |
 | `homeSetters` / `awaySetters` / `nightSetters` | Entities invoked when that mode is reached, comma-separated. |
 | `offSetters` | Entities invoked on disarm. |
 | `homeTriggers` / `awayTriggers` / `nightTriggers` | Sensors that trip the alarm in that mode. |
@@ -201,7 +202,7 @@ Every entity field is a comma-separated list, deduplicated on parse. Alert lists
 
 Known limits: changing `haUrl`/`haToken` while silences or setters are still pending can replay them against the new Home Assistant, and a silence that keeps failing is retried on every reconnect without a cap. Both are on the list for the next revision.
 
-If you already run Alarmo or another alarm integration, keep using it and bridge its `alarm_control_panel` entity instead. This plugin runs its own state machine, so pointing both at the same sensors gives you two independent alarms that do not know about each other. The first version targets users without an alarm integration.
+If you already run Alarmo or another alarm integration, keep it as the source of truth and set `sourceAlarmPanel` to its `alarm_control_panel.*` entity. The four Matter switches and Alarm contact sensor then follow the panel's initial state and subsequent `state_changed` events. Matter switch writes call `alarm_arm_home`, `alarm_arm_away`, `alarm_arm_night`, `alarm_arm_vacation`, or `alarm_disarm` on that entity. Local trigger, setter, alert, and silence logic stays inactive while a source panel is configured.
 
 ### Cluster IDs
 

--- a/packages/backend/src/plugins/builtin/security/security-plugin.test.ts
+++ b/packages/backend/src/plugins/builtin/security/security-plugin.test.ts
@@ -59,7 +59,9 @@ interface ServiceMessage {
 function fakeConnection() {
   return {
     connected: true,
-    sendMessagePromise: vi.fn(async (_msg: ServiceMessage) => ({})),
+    sendMessagePromise: vi.fn(async (msg: ServiceMessage) =>
+      msg.type === "get_states" ? [] : {},
+    ),
     subscribeEvents: vi.fn(async () => () => {}),
     addEventListener: vi.fn(),
     close: vi.fn(),
@@ -111,6 +113,204 @@ describe("SecurityPlugin", () => {
     await plugin.onShutdown();
   });
 
+  it("registers devices for a source alarm panel without dummy triggers", async () => {
+    const conn = fakeConnection();
+    const { ctx, devices } = createMockContext({ homeAssistant: ha });
+    const plugin = new SecurityPlugin(
+      { sourceAlarmPanel: "alarm_control_panel.house" },
+      { connect: async () => conn as unknown as Connection },
+    );
+
+    await plugin.onStart(ctx);
+
+    expect(devices.size).toBe(5);
+    expect(ctx.registerDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "mode_home" }),
+    );
+    await plugin.onShutdown();
+  });
+
+  it("reads and mirrors the source alarm panel after connecting", async () => {
+    const conn = fakeConnection();
+    conn.sendMessagePromise = vi.fn(async (msg: ServiceMessage) =>
+      msg.type === "get_states"
+        ? [{ entity_id: "alarm_control_panel.house", state: "armed_home" }]
+        : {},
+    );
+    const { ctx } = createMockContext({ homeAssistant: ha });
+    const plugin = new SecurityPlugin(
+      {
+        sourceAlarmPanel: "alarm_control_panel.house",
+        homeSetters: "scene.arm_home",
+      },
+      { connect: async () => conn as unknown as Connection },
+    );
+
+    await plugin.onStart(ctx);
+
+    await vi.waitFor(() => {
+      expect(ctx.updateDeviceState).toHaveBeenCalledWith("mode_home", "onOff", {
+        onOff: true,
+      });
+    });
+    expect(ctx.updateDeviceState).toHaveBeenCalledWith(
+      "alarm",
+      "booleanState",
+      { stateValue: true },
+    );
+    const services = conn.sendMessagePromise.mock.calls
+      .map(([message]) => message)
+      .filter((message) => message.type === "call_service");
+    expect(services).toEqual([]);
+    await plugin.onShutdown();
+  });
+
+  it("mirrors source state events, including the triggered contact state", async () => {
+    let stateHandler: ((event: unknown) => void) | undefined;
+    const conn = {
+      ...fakeConnection(),
+      sendMessagePromise: vi.fn(async (msg: ServiceMessage) =>
+        msg.type === "get_states"
+          ? [{ entity_id: "alarm_control_panel.house", state: "armed_away" }]
+          : {},
+      ),
+      subscribeEvents: vi.fn(async (handler: (event: unknown) => void) => {
+        stateHandler = handler;
+        return () => {};
+      }),
+    };
+    const { ctx } = createMockContext({ homeAssistant: ha });
+    const plugin = new SecurityPlugin(
+      { sourceAlarmPanel: "alarm_control_panel.house" },
+      { connect: async () => conn as unknown as Connection },
+    );
+    await plugin.onStart(ctx);
+    await vi.waitFor(() => expect(stateHandler).toBeDefined());
+
+    stateHandler?.({
+      data: {
+        entity_id: "alarm_control_panel.house",
+        old_state: { state: "armed_away" },
+        new_state: { state: "armed_night", attributes: {} },
+      },
+    });
+    expect(ctx.updateDeviceState).toHaveBeenCalledWith("mode_night", "onOff", {
+      onOff: true,
+    });
+
+    stateHandler?.({
+      data: {
+        entity_id: "alarm_control_panel.house",
+        old_state: { state: "armed_night" },
+        new_state: { state: "triggered", attributes: {} },
+      },
+    });
+    expect(ctx.updateDeviceState).toHaveBeenCalledWith(
+      "alarm",
+      "booleanState",
+      { stateValue: false },
+    );
+    await plugin.onShutdown();
+  });
+
+  it("forwards Matter mode writes to the source alarm panel", async () => {
+    let sourceState = "disarmed";
+    const conn = fakeConnection();
+    conn.sendMessagePromise = vi.fn(async (msg: ServiceMessage) => {
+      if (msg.type === "get_states") {
+        return [{ entity_id: "alarm_control_panel.house", state: sourceState }];
+      }
+      return {};
+    });
+    const { ctx, devices } = createMockContext({ homeAssistant: ha });
+    const plugin = new SecurityPlugin(
+      { sourceAlarmPanel: "alarm_control_panel.house" },
+      { connect: async () => conn as unknown as Connection },
+    );
+    await plugin.onStart(ctx);
+    await vi.waitFor(() =>
+      expect(conn.sendMessagePromise).toHaveBeenCalledWith({
+        type: "get_states",
+      }),
+    );
+
+    await armVia(devices, "mode_night");
+    await vi.waitFor(() => {
+      expect(conn.sendMessagePromise).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "call_service",
+          domain: "alarm_control_panel",
+          service: "alarm_arm_night",
+          target: { entity_id: "alarm_control_panel.house" },
+        }),
+      );
+    });
+
+    sourceState = "armed_night";
+    await (
+      plugin as unknown as {
+        syncSourceAlarmState(): Promise<void>;
+      }
+    ).syncSourceAlarmState();
+    await devices
+      .get("mode_night")
+      ?.onAttributeWrite?.("onOff", "onOff", false);
+    await vi.waitFor(() => {
+      expect(conn.sendMessagePromise).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "call_service",
+          domain: "alarm_control_panel",
+          service: "alarm_disarm",
+          target: { entity_id: "alarm_control_panel.house" },
+        }),
+      );
+    });
+    await plugin.onShutdown();
+  });
+
+  it("does not run local triggers or alerts while a source panel owns state", async () => {
+    const conn = fakeConnection();
+    conn.sendMessagePromise = vi.fn(async (msg: ServiceMessage) =>
+      msg.type === "get_states"
+        ? [{ entity_id: "alarm_control_panel.house", state: "armed_home" }]
+        : {},
+    );
+    const { ctx } = createMockContext({ homeAssistant: ha });
+    const plugin = new SecurityPlugin(
+      {
+        sourceAlarmPanel: "alarm_control_panel.house",
+        exitDelaySeconds: 0,
+        homeTriggers: "binary_sensor.motion",
+        homeAlerts: "siren.horn",
+      },
+      { connect: async () => conn as unknown as Connection },
+    );
+    await plugin.onStart(ctx);
+    await vi.waitFor(() => {
+      expect(ctx.updateDeviceState).toHaveBeenCalledWith("mode_home", "onOff", {
+        onOff: true,
+      });
+    });
+
+    plugin.handleTriggerEvent("binary_sensor.motion", "on", "motion");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const alertCalls = conn.sendMessagePromise.mock.calls
+      .map(([message]) => message)
+      .filter(
+        (message) =>
+          message.type === "call_service" &&
+          message.target?.entity_id === "siren.horn",
+      );
+    expect(alertCalls).toEqual([]);
+    expect(ctx.updateDeviceState).not.toHaveBeenCalledWith(
+      "alarm",
+      "booleanState",
+      { stateValue: false },
+    );
+    await plugin.onShutdown();
+  });
+
   it("mounts the devices live when a config change adds a trigger (#439)", async () => {
     const { ctx, devices } = createMockContext();
     const plugin = new SecurityPlugin();
@@ -155,6 +355,7 @@ describe("SecurityPlugin", () => {
       "exitDelaySeconds",
       "entryDelaySeconds",
       "triggerTimeSeconds",
+      "sourceAlarmPanel",
       "homeSetters",
       "homeTriggers",
       "homeAlerts",
@@ -181,6 +382,7 @@ describe("SecurityPlugin", () => {
     });
     expect(schema.properties.entryDelaySeconds.default).toBe(60);
     expect(schema.properties.triggerTimeSeconds.default).toBe(120);
+    expect(schema.properties.sourceAlarmPanel.title).toBe("Source alarm panel");
     expect(schema.properties.alwaysAlerts.title).toBe("Always");
     // The fallback is a documented behavior, the field description must say it.
     expect(schema.properties.vacationSetters.description).toMatch(/away/i);

--- a/packages/backend/src/plugins/builtin/security/security-plugin.ts
+++ b/packages/backend/src/plugins/builtin/security/security-plugin.ts
@@ -4,7 +4,9 @@ import {
   callService,
   createConnection,
   createLongLivedTokenAuth,
+  type HassEntity,
 } from "home-assistant-js-websocket";
+import { sendHaMessage } from "../../../utils/send-ha-message.js";
 import type {
   MatterHubPlugin,
   PluginConfigSchema,
@@ -15,6 +17,7 @@ import {
   type ArmMode,
   alertsForTier,
   isPerimeterTrigger,
+  type ObservedSecurityState,
   type ResolvedSecurityLists,
   resolveSecurityLists,
   type SecurityEffects,
@@ -28,6 +31,7 @@ import {
 interface SecurityConfig {
   haUrl?: string;
   haToken?: string;
+  sourceAlarmPanel?: string;
   exitDelaySeconds?: number;
   entryDelaySeconds?: number;
   triggerTimeSeconds?: number;
@@ -112,9 +116,9 @@ type EffectTask = (
 // The state machine itself is pure, see security-state-machine.ts; this class
 // wires it to the plugin devices and to Home Assistant.
 //
-// Independent by design: this runs its own state machine in plugin storage.
-// Bridging an alarm_control_panel entity (Alarmo etc.) alongside it against
-// the same sensors gives two alarms that do not know about each other.
+// By default this runs its own state machine in plugin storage. When a source
+// alarm panel is configured, Home Assistant owns the alarm state: this plugin
+// mirrors that panel and forwards Matter mode writes back to it.
 export class SecurityPlugin implements MatterHubPlugin {
   readonly name = "security";
   readonly version = "0.1.0";
@@ -156,11 +160,11 @@ export class SecurityPlugin implements MatterHubPlugin {
     const stored = await context.storage.get<SecurityConfig>(CONFIG_KEY);
     this.config = { ...this.config, ...(stored ?? {}) };
     this.applyLists();
-    // Without a single trigger the alarm can never trip, so an untouched
-    // install must not spill five endpoints onto the bridge (#439).
+    // Without a trigger or source panel the alarm can never change, so an
+    // untouched install must not spill five endpoints onto the bridge (#439).
     if (!this.isConfigured()) {
       this.log.info(
-        "no trigger entities configured, the security devices stay unregistered",
+        "no trigger entities or source alarm panel configured, the security devices stay unregistered",
       );
       return;
     }
@@ -168,7 +172,7 @@ export class SecurityPlugin implements MatterHubPlugin {
   }
 
   private isConfigured(): boolean {
-    return this.watched.size > 0;
+    return this.watched.size > 0 || this.sourceAlarmPanel() != null;
   }
 
   private async bringUp(): Promise<void> {
@@ -180,29 +184,39 @@ export class SecurityPlugin implements MatterHubPlugin {
       this.effects(),
     );
     await this.registerDevices();
-    // A restart mid-armed comes back armed, see restore() for the resolution
-    // of interrupted delays.
     const state = await context.storage.get<StoredSecurityState>(STATE_KEY);
-    this.machine.restore(state);
-    // The resolved snapshot goes to disk before any of its effects dispatch.
-    await context.storage.flush?.();
-    if (state?.phase === "triggered") {
-      // The pre-restart trip's alert set travels in the snapshot. Old
-      // snapshots without it fall back to anything any tier could have
-      // started.
-      const known = state.activeAlerts;
-      if (this.machine.snapshot.phase === "triggered") {
-        // Still triggered: arm the first clear.
-        this.activeAlerts = known ?? this.allSilenceableAlerts();
-      } else {
-        // A finite trigger time resolved the restore out of triggered, so no
-        // disarm will ever clear the pre-restart sirens. Silence them now.
-        const candidates = (known ?? this.allSilenceableAlerts()).filter((id) =>
-          SILENCEABLE_ALERT_DOMAINS.has(id.split(".")[0]),
-        );
-        this.enqueueSilence(candidates);
+    if (this.sourceAlarmPanel()) {
+      if (state) {
+        this.machine.applyObservedState({
+          mode: state.mode,
+          phase: state.phase,
+        });
+      }
+      this.activeAlerts = [];
+    } else {
+      // A restart mid-armed comes back armed, see restore() for the resolution
+      // of interrupted delays.
+      this.machine.restore(state);
+      if (state?.phase === "triggered") {
+        // The pre-restart trip's alert set travels in the snapshot. Old
+        // snapshots without it fall back to anything any tier could have
+        // started.
+        const known = state.activeAlerts;
+        if (this.machine.snapshot.phase === "triggered") {
+          // Still triggered: arm the first clear.
+          this.activeAlerts = known ?? this.allSilenceableAlerts();
+        } else {
+          // A finite trigger time resolved the restore out of triggered, so no
+          // disarm will ever clear the pre-restart sirens. Silence them now.
+          const candidates = (known ?? this.allSilenceableAlerts()).filter(
+            (id) => SILENCEABLE_ALERT_DOMAINS.has(id.split(".")[0]),
+          );
+          this.enqueueSilence(candidates);
+        }
       }
     }
+    // The resolved snapshot goes to disk before any of its effects dispatch.
+    await context.storage.flush?.();
     this.pushDeviceStates();
     this.startConnection();
   }
@@ -221,18 +235,26 @@ export class SecurityPlugin implements MatterHubPlugin {
   }
 
   async onConfigChanged(config: Record<string, unknown>): Promise<void> {
+    const previousSource = this.sourceAlarmPanel();
     this.config = config as SecurityConfig;
     await this.context?.storage.set(CONFIG_KEY, this.config);
     this.applyLists();
     if (!this.isConfigured()) {
       if (this.machine) {
-        this.log.info("trigger lists emptied, removing the security devices");
+        this.log.info(
+          "security config has no trigger entities or source alarm panel, removing the security devices",
+        );
         await this.tearDown();
       }
       return;
     }
     if (!this.machine) {
       // First real config: the devices mount now, no bridge restart needed.
+      await this.bringUp();
+      return;
+    }
+    if (previousSource !== this.sourceAlarmPanel()) {
+      await this.tearDown();
       await this.bringUp();
       return;
     }
@@ -288,6 +310,14 @@ export class SecurityPlugin implements MatterHubPlugin {
             "How long the alarm stays triggered before returning to the " +
             "state it was tripped from. 0 keeps it triggered until disarm.",
           default: 120,
+          required: false,
+        },
+        sourceAlarmPanel: {
+          type: "string",
+          title: "Source alarm panel",
+          description:
+            "Existing alarm_control_panel.* entity to mirror. When set, " +
+            "Home Assistant owns the state and Matter mode changes call its alarm services.",
           required: false,
         },
         homeSetters: entityList(
@@ -381,6 +411,7 @@ export class SecurityPlugin implements MatterHubPlugin {
     state: string,
     deviceClass?: string,
   ): void {
+    if (this.sourceAlarmPanel()) return;
     if (state !== "on" && state !== "open") return;
     if (!this.watched.has(entityId)) return;
     this.machine?.handleEntityOn(
@@ -395,6 +426,12 @@ export class SecurityPlugin implements MatterHubPlugin {
       (message) => this.log.warn(message),
     );
     this.watched = watchedTriggerEntities(this.lists);
+    const source = this.config.sourceAlarmPanel?.trim();
+    if (source && !source.startsWith("alarm_control_panel.")) {
+      this.log.warn(
+        `source alarm panel ignored, expected alarm_control_panel.* but got ${source}`,
+      );
+    }
   }
 
   private machineConfig(): SecurityMachineConfig {
@@ -486,6 +523,10 @@ export class SecurityPlugin implements MatterHubPlugin {
         clusters: [{ clusterId: "onOff", attributes: { onOff: false } }],
         onAttributeWrite: async (clusterId, attribute, value) => {
           if (clusterId !== "onOff" || attribute !== "onOff") return;
+          if (this.sourceAlarmPanel()) {
+            await this.handleSourceModeWrite(mode, value === true);
+            return;
+          }
           this.machine?.handleModeSwitch(mode, value === true);
         },
       });
@@ -499,6 +540,11 @@ export class SecurityPlugin implements MatterHubPlugin {
         { clusterId: "booleanState", attributes: { stateValue: true } },
       ],
     });
+  }
+
+  private sourceAlarmPanel(): string | undefined {
+    const source = this.config.sourceAlarmPanel?.trim();
+    return source?.startsWith("alarm_control_panel.") ? source : undefined;
   }
 
   // Reflect the restored snapshot onto the endpoints.
@@ -684,6 +730,11 @@ export class SecurityPlugin implements MatterHubPlugin {
   // Ran after every (re)connect: sirens first, then any setter batch a gap
   // swallowed, but only if the machine still stands where it did.
   private async flushAfterConnect(): Promise<void> {
+    if (this.sourceAlarmPanel()) {
+      await this.context?.storage.delete(PENDING_SETTERS_KEY);
+      await this.syncSourceAlarmState();
+      return;
+    }
     await this.flushPendingSilence();
     const storage = this.context?.storage;
     if (!storage) return;
@@ -727,7 +778,7 @@ export class SecurityPlugin implements MatterHubPlugin {
   private async callWithDeadline(
     connection: Connection,
     domain: string,
-    service: "turn_on" | "turn_off",
+    service: string,
     entityId: string,
   ): Promise<void> {
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -809,7 +860,11 @@ export class SecurityPlugin implements MatterHubPlugin {
         return;
       }
       this.unsubscribeEvents = unsubscribe;
-      this.log.info(`watching ${this.watched.size} trigger entities`);
+      const source = this.sourceAlarmPanel();
+      this.log.info(
+        `watching ${this.watched.size} trigger entities` +
+          (source ? ` and source alarm panel ${source}` : ""),
+      );
       this.enqueueReconnect();
     } catch (e) {
       // Close the half-open socket before any retry.
@@ -851,6 +906,102 @@ export class SecurityPlugin implements MatterHubPlugin {
     this.backoffMs = RETRY_BASE_MS;
   }
 
+  private async syncSourceAlarmState(): Promise<void> {
+    const source = this.sourceAlarmPanel();
+    const connection = this.connection;
+    if (!source || !connection?.connected) return;
+    try {
+      const states = await sendHaMessage<HassEntity[]>(
+        connection,
+        { type: "get_states" },
+        CALL_DEADLINE_MS,
+      );
+      const sourceState = states.find((state) => state.entity_id === source);
+      if (!sourceState) {
+        this.log.warn(`source alarm panel ${source} was not found`);
+        return;
+      }
+      await this.mirrorSourceAlarmState(source, sourceState.state);
+    } catch (e) {
+      this.log.warn(`failed to read source alarm panel ${source}:`, e);
+    }
+  }
+
+  private async mirrorSourceAlarmState(
+    entityId: string,
+    state: string,
+  ): Promise<void> {
+    const observed = this.observedStateFromAlarmPanel(state);
+    if (!observed) {
+      this.log.debug(`source alarm panel ${entityId} state ignored: ${state}`);
+      return;
+    }
+    this.machine?.applyObservedState(observed);
+    this.pushDeviceStates();
+    await this.context?.storage.flush?.();
+  }
+
+  private observedStateFromAlarmPanel(
+    state: string,
+  ): ObservedSecurityState | undefined {
+    switch (state) {
+      case "disarmed":
+        return { mode: null, phase: "disarmed" };
+      case "armed_home":
+        return { mode: "home", phase: "armed" };
+      case "armed_away":
+        return { mode: "away", phase: "armed" };
+      case "armed_night":
+        return { mode: "night", phase: "armed" };
+      case "armed_vacation":
+        return { mode: "vacation", phase: "armed" };
+      case "arming":
+      case "pending":
+      case "triggered":
+        return { phase: state };
+      default:
+        return undefined;
+    }
+  }
+
+  private async handleSourceModeWrite(
+    mode: ArmMode,
+    on: boolean,
+  ): Promise<void> {
+    const source = this.sourceAlarmPanel();
+    const connection = this.connection;
+    if (!source || !connection?.connected) {
+      this.log.warn(
+        "source alarm panel write skipped, Home Assistant is not connected",
+      );
+      this.pushDeviceStates();
+      return;
+    }
+
+    const snapshot = this.machine?.snapshot;
+    const service = on
+      ? `alarm_arm_${mode}`
+      : snapshot?.mode === mode && snapshot.phase !== "disarmed"
+        ? "alarm_disarm"
+        : undefined;
+    if (!service) {
+      this.pushDeviceStates();
+      return;
+    }
+
+    try {
+      await this.callWithDeadline(
+        connection,
+        "alarm_control_panel",
+        service,
+        source,
+      );
+    } catch (e) {
+      this.log.warn(`${service} failed for source alarm panel ${source}:`, e);
+      this.pushDeviceStates();
+    }
+  }
+
   private handleStateChanged(event: HaStateChangedEvent): void {
     const entityId = event.data?.entity_id;
     const newState = event.data?.new_state;
@@ -858,6 +1009,10 @@ export class SecurityPlugin implements MatterHubPlugin {
     // state_changed also fires on attribute-only updates; only a real state
     // entry counts.
     if (event.data?.old_state?.state === newState.state) return;
+    if (entityId === this.sourceAlarmPanel()) {
+      void this.mirrorSourceAlarmState(entityId, newState.state);
+      return;
+    }
     this.handleTriggerEvent(
       entityId,
       newState.state,

--- a/packages/backend/src/plugins/builtin/security/security-state-machine.test.ts
+++ b/packages/backend/src/plugins/builtin/security/security-state-machine.test.ts
@@ -222,6 +222,45 @@ describe("SecurityStateMachine", () => {
     expect(rec.disarmed).toBe(1);
   });
 
+  it("mirrors an observed mode without running local alarm effects", () => {
+    const { m, rec, sched } = machine();
+
+    const changed = m.applyObservedState({ mode: "away", phase: "armed" });
+
+    expect(changed).toBe(true);
+    expect(m.snapshot).toEqual({ mode: "away", phase: "armed" });
+    expect(rec.switches.at(-1)).toEqual({ ...allOff, away: true });
+    expect(rec.reached).toEqual([]);
+    expect(rec.disarmed).toBe(0);
+    expect(rec.tripped).toEqual([]);
+    expect(rec.cleared).toBe(0);
+    expect(sched.live()).toEqual([]);
+  });
+
+  it("preserves the observed mode across phase-only updates", () => {
+    const { m, rec } = machine();
+    m.applyObservedState({ mode: "night", phase: "armed" });
+
+    m.applyObservedState({ phase: "triggered" });
+
+    expect(m.snapshot).toEqual({ mode: "night", phase: "triggered" });
+    expect(rec.switches.at(-1)).toEqual({ ...allOff, night: true });
+    expect(rec.tripped).toEqual([]);
+  });
+
+  it("mirrors an observed disarm without running off setters", () => {
+    const { m, rec } = machine({ exitDelaySeconds: 0 });
+    m.handleModeSwitch("home", true);
+    rec.reached = [];
+
+    m.applyObservedState({ mode: null, phase: "disarmed" });
+
+    expect(m.snapshot).toEqual({ mode: null, phase: "disarmed" });
+    expect(rec.switches.at(-1)).toEqual(allOff);
+    expect(rec.reached).toEqual([]);
+    expect(rec.disarmed).toBe(0);
+  });
+
   it("does not re-run setters when the armed switch is set on again", () => {
     const { m, rec } = machine({ exitDelaySeconds: 0 });
     m.handleModeSwitch("home", true);

--- a/packages/backend/src/plugins/builtin/security/security-state-machine.ts
+++ b/packages/backend/src/plugins/builtin/security/security-state-machine.ts
@@ -29,6 +29,12 @@ export interface SecuritySnapshot {
   modeReached?: boolean;
 }
 
+export interface ObservedSecurityState {
+  /** Omit the mode for phase-only updates such as pending or triggered. */
+  mode?: ArmMode | null;
+  phase?: SecurityPhase;
+}
+
 export interface SecurityMachineConfig {
   /** Exit delay before an armed mode takes effect. 0 arms immediately. */
   exitDelaySeconds: number;
@@ -371,6 +377,33 @@ export class SecurityStateMachine {
     }
   }
 
+  // Mirrors a state owned by an external alarm panel. This observation path
+  // updates only the reported switches and persisted snapshot: local setters,
+  // alerts and silence handlers must not run for an alarm owned elsewhere.
+  applyObservedState(state: ObservedSecurityState): boolean {
+    this.clearTimer();
+    let nextMode =
+      state.mode === undefined
+        ? this.mode
+        : this.normalizeObservedMode(state.mode);
+    const nextPhase = this.normalizeObservedPhase(state.phase, nextMode);
+    if (nextPhase === "disarmed") nextMode = null;
+
+    if (this.mode === nextMode && this.phase === nextPhase) {
+      this.reportSwitches();
+      return false;
+    }
+
+    this.mode = nextMode;
+    this.phase = nextPhase;
+    this.returnMode = nextPhase === "triggered" ? nextMode : null;
+    this.trippedTier = null;
+    this.modeReachedRan = true;
+    this.reportSwitches();
+    this.persist();
+    return true;
+  }
+
   shutdown(): void {
     this.clearTimer();
   }
@@ -418,6 +451,22 @@ export class SecurityStateMachine {
     const states = {} as Record<ArmMode, boolean>;
     for (const mode of ARM_MODES) states[mode] = mode === active;
     this.effects.switchStates(states);
+  }
+
+  private normalizeObservedMode(mode: ObservedSecurityState["mode"]) {
+    if (mode == null) return null;
+    return ARM_MODES.includes(mode) ? mode : null;
+  }
+
+  private normalizeObservedPhase(
+    phase: ObservedSecurityState["phase"],
+    mode: ArmMode | null,
+  ): SecurityPhase {
+    if (phase === "triggered") return phase;
+    if (phase === "arming" || phase === "pending" || phase === "armed") {
+      return mode ? phase : "disarmed";
+    }
+    return mode ? "armed" : "disarmed";
   }
 
   private persist(): void {


### PR DESCRIPTION
## Problem

The security plugin currently works only as an independent alarm system. That is useful when Home Assistant has no alarm integration, but it creates a second source of truth for users who already have Alarmo, an Aqara hub, or another integration exposing `alarm_control_panel.*`.

Using the same sensors in both systems does not solve this: arming, disarming, pending, and triggered states can diverge, while Matter controllers still have no representation of the existing Home Assistant alarm panel.

## Proposed behavior

This PR adds one optional setting, `sourceAlarmPanel`, to the existing security plugin. When configured, the current four mode switches and Alarm contact sensor become a Matter-facing view of that Home Assistant alarm panel instead of running a second alarm state machine.

State mapping:

| Home Assistant state | Matter-facing state |
| --- | --- |
| `disarmed` | all mode switches off; Alarm closed |
| `armed_home` | Home on |
| `armed_away` | Away on |
| `armed_night` | Night on |
| `armed_vacation` | Vacation on |
| `arming` / `pending` | retain the selected mode and update the phase |
| `triggered` | retain the selected mode; Alarm contact opens |

The source is read after the Home Assistant connection is established and again after reconnects. Subsequent `state_changed` events keep Matter synchronized without polling.

Writes also flow back to Home Assistant:

- turning on a mode calls the corresponding `alarm_arm_*` service
- turning off the active mode calls `alarm_disarm`
- turning off an inactive mode is ignored and the authoritative state is re-published

## Safety and compatibility

- Existing behavior is unchanged when `sourceAlarmPanel` is not configured.
- A source panel alone is enough to register the five existing endpoints; no dummy trigger is required.
- While a source panel owns the state, local triggers, setters, alerts, and silence handlers stay inactive. This prevents duplicate alarm logic and side effects.
- Mirrored updates use an observation-only state-machine path: they update switches, the Alarm contact, and persisted state without invoking local automation effects.
- Unsupported or unavailable source states keep the last known state instead of inventing a transition.
- No new Matter device type, external API, or plugin loading mechanism is introduced.

This keeps the change scoped to the existing security plugin and reuses its current Matter endpoint contract.

## Verification

- 80 focused security plugin and state-machine tests pass
- backend TypeScript build passes
