### PR TITLE
fix(plugins): complete the third-party plugin runtime

### DIFF
--- a/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
+++ b/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { Environment, Logger, VariableService } from "@matter/general";
 import type { Endpoint } from "@matter/main";
 import { VendorId } from "@matter/main";
-import { BasicInformationServer } from "@matter/main/behaviors";
 import {
   ContactSensorDevice,
   OnOffPlugInUnitDevice,
@@ -84,11 +83,6 @@ async function bringUp() {
     manager,
   );
   await server.add(bem.root);
-  bem.setTopologyChangeHandler(async (change) => {
-    await server!.act("plugin topology change", (agent) =>
-      agent.get(BasicInformationServer).increaseConfigurationVersion(change),
-    );
-  });
   // Production order (bridge.ts runStart): the node starts before the plugins
   // register, so behavior events exist when the endpoint wiring attaches.
   await server.start();
@@ -120,23 +114,11 @@ describe("security plugin bring-up (#419)", () => {
     const { manager, endpoints } = await bringUp();
 
     expect([...endpoints.keys()]).toEqual([...MODE_IDS, "alarm"]);
-    for (const [id, name] of [
-      ["mode_home", "Home"],
-      ["mode_away", "Away"],
-      ["mode_night", "Night"],
-      ["mode_vacation", "Vacation"],
-    ] as const) {
+    for (const id of MODE_IDS) {
       expect(endpoints.get(id)!.type.deviceType).toBe(
         OnOffPlugInUnitDevice.deviceType,
       );
       expect(stateOf(endpoints.get(id)!).onOff.onOff).toBe(false);
-      expect(
-        stateOf(endpoints.get(id)!).bridgedDeviceBasicInformation,
-      ).toMatchObject({
-        nodeLabel: name,
-        productName: name,
-        productLabel: name,
-      });
     }
     expect(endpoints.get("alarm")!.type.deviceType).toBe(
       ContactSensorDevice.deviceType,
@@ -210,21 +192,6 @@ describe("security plugin bring-up (#419)", () => {
     await bem.enablePlugin("security");
     expect([...bem.root.parts].length).toBe(5);
     expect(manager.getMetadata()[0].enabled).toBe(true);
-
-    await manager.shutdownAll();
-  });
-
-  it("increments the root configuration version when plugin endpoints change", async () => {
-    const { manager, bem } = await bringUp();
-
-    expect(server!.stateOf(BasicInformationServer).configurationVersion).toBe(
-      6,
-    );
-
-    await bem.disablePlugin("security");
-    expect(server!.stateOf(BasicInformationServer).configurationVersion).toBe(
-      11,
-    );
 
     await manager.shutdownAll();
   });

--- a/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
+++ b/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { Environment, Logger, VariableService } from "@matter/general";
 import type { Endpoint } from "@matter/main";
 import { VendorId } from "@matter/main";
+import { BasicInformationServer } from "@matter/main/behaviors";
 import {
   ContactSensorDevice,
   OnOffPlugInUnitDevice,
@@ -83,6 +84,11 @@ async function bringUp() {
     manager,
   );
   await server.add(bem.root);
+  bem.setTopologyChangeHandler(async (change) => {
+    await server!.act("plugin topology change", (agent) =>
+      agent.get(BasicInformationServer).increaseConfigurationVersion(change),
+    );
+  });
   // Production order (bridge.ts runStart): the node starts before the plugins
   // register, so behavior events exist when the endpoint wiring attaches.
   await server.start();
@@ -192,6 +198,21 @@ describe("security plugin bring-up (#419)", () => {
     await bem.enablePlugin("security");
     expect([...bem.root.parts].length).toBe(5);
     expect(manager.getMetadata()[0].enabled).toBe(true);
+
+    await manager.shutdownAll();
+  });
+
+  it("increments the root configuration version when plugin endpoints change", async () => {
+    const { manager, bem } = await bringUp();
+
+    expect(server!.stateOf(BasicInformationServer).configurationVersion).toBe(
+      6,
+    );
+
+    await bem.disablePlugin("security");
+    expect(server!.stateOf(BasicInformationServer).configurationVersion).toBe(
+      11,
+    );
 
     await manager.shutdownAll();
   });

--- a/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
+++ b/packages/backend/src/plugins/builtin/security/security-419-bringup.test.ts
@@ -120,11 +120,23 @@ describe("security plugin bring-up (#419)", () => {
     const { manager, endpoints } = await bringUp();
 
     expect([...endpoints.keys()]).toEqual([...MODE_IDS, "alarm"]);
-    for (const id of MODE_IDS) {
+    for (const [id, name] of [
+      ["mode_home", "Home"],
+      ["mode_away", "Away"],
+      ["mode_night", "Night"],
+      ["mode_vacation", "Vacation"],
+    ] as const) {
       expect(endpoints.get(id)!.type.deviceType).toBe(
         OnOffPlugInUnitDevice.deviceType,
       );
       expect(stateOf(endpoints.get(id)!).onOff.onOff).toBe(false);
+      expect(
+        stateOf(endpoints.get(id)!).bridgedDeviceBasicInformation,
+      ).toMatchObject({
+        nodeLabel: name,
+        productName: name,
+        productLabel: name,
+      });
     }
     expect(endpoints.get("alarm")!.type.deviceType).toBe(
       ContactSensorDevice.deviceType,

--- a/packages/backend/src/plugins/plugin-basic-information-server.ts
+++ b/packages/backend/src/plugins/plugin-basic-information-server.ts
@@ -18,7 +18,8 @@ export class PluginBasicInformationServer extends BridgedDeviceBasicInformationS
     applyPatchState(this.state, {
       vendorId: VendorId(basicInformation.vendorId),
       vendorName: truncate(32, pluginDevice.pluginName),
-      productName: truncate(32, device.deviceType ?? device.name),
+      productName: truncate(32, device.name),
+      productLabel: truncate(64, device.name),
       nodeLabel: truncate(32, device.name),
       serialNumber: crypto
         .createHash("md5")

--- a/packages/backend/src/plugins/plugin-manager.test.ts
+++ b/packages/backend/src/plugins/plugin-manager.test.ts
@@ -818,6 +818,52 @@ export default class TestPlugin {
       expect(pm.getMetadata()[0].source).toBe(pluginDir);
     });
 
+    it("should load the manifest main entry instead of importing the package directory", async () => {
+      const pluginDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "hamh-test-plugin-main-"),
+      );
+      tempDirs.push(pluginDir);
+      fs.mkdirSync(path.join(pluginDir, "dist"));
+      fs.writeFileSync(
+        path.join(pluginDir, "package.json"),
+        JSON.stringify({
+          name: "nested-main-plugin",
+          version: "0.1.0",
+          main: "dist/plugin.js",
+          type: "module",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDir, "dist", "plugin.js"),
+        `export default class NestedMainPlugin {
+  name = "nested-main-plugin";
+  version = "0.1.0";
+  async onStart() {}
+}`,
+      );
+
+      const pm = new PluginManager("bridge-1", storageDir);
+      await pm.loadExternal(pluginDir, {});
+
+      expect(pm.getMetadata()[0].name).toBe("nested-main-plugin");
+    });
+
+    it("should reject a manifest main entry outside the package directory", async () => {
+      const pluginDir = createTempPlugin(
+        "export default class X {}",
+        "escaping-main-plugin",
+      );
+      const manifestPath = path.join(pluginDir, "package.json");
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+      manifest.main = "../outside.js";
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const pm = new PluginManager("bridge-1", storageDir);
+      await expect(pm.loadExternal(pluginDir, {})).rejects.toThrow(
+        "must stay inside the package directory",
+      );
+    });
+
     it("should reject plugin without package.json", async () => {
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hamh-test-nopkg-"));
       tempDirs.push(dir);

--- a/packages/backend/src/plugins/plugin-manager.ts
+++ b/packages/backend/src/plugins/plugin-manager.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { Logger } from "@matter/general";
 import { getSupportedPluginDeviceTypes } from "./plugin-device-factory.js";
 import type { PluginRegistry } from "./plugin-registry.js";
@@ -195,10 +196,26 @@ export class PluginManager {
         );
       }
 
+      const packageRoot = path.resolve(packagePath);
+      const entryPath = path.resolve(packageRoot, manifest.main);
+      if (
+        entryPath !== packageRoot &&
+        !entryPath.startsWith(`${packageRoot}${path.sep}`)
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}" main entry must stay inside the package directory`,
+        );
+      }
+      if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+        throw new Error(
+          `Plugin "${manifest.name}" main entry does not exist: ${manifest.main}`,
+        );
+      }
+
       const module = await this.runner.run(
         manifest.name,
         "import",
-        () => import(packagePath),
+        () => import(pathToFileURL(entryPath).href),
         15_000,
       );
       if (!module) {

--- a/packages/backend/src/services/bridges/bridge-endpoint-manager.ts
+++ b/packages/backend/src/services/bridges/bridge-endpoint-manager.ts
@@ -103,6 +103,9 @@ export class BridgeEndpointManager extends Service {
   private readonly pluginEndpoints = new Map<string, Endpoint>();
   private readonly pluginStateUpdating = new Set<string>();
   private readonly pluginListeners = new Map<string, PluginListenerRef[]>();
+  private topologyChangeHandler = async (change: () => Promise<unknown>) => {
+    await change();
+  };
 
   get failedEntities(): FailedEntity[] {
     // Combine static failed entities with dynamically isolated entities
@@ -152,6 +155,12 @@ export class BridgeEndpointManager extends Service {
     if (this.pluginManager) {
       this.wirePluginCallbacks();
     }
+  }
+
+  setTopologyChangeHandler(
+    handler: (change: () => Promise<unknown>) => Promise<void>,
+  ): void {
+    this.topologyChangeHandler = handler;
   }
 
   private wirePluginCallbacks(): void {
@@ -246,7 +255,7 @@ export class BridgeEndpointManager extends Service {
         });
       }
       try {
-        await this.root.add(endpoint);
+        await this.topologyChangeHandler(() => this.root.add(endpoint));
         this.pluginEndpoints.set(device.id, endpoint);
         this.wirePluginEndpointEvents(device, endpoint);
         this.log.info(
@@ -283,9 +292,9 @@ export class BridgeEndpointManager extends Service {
             // A reversible stop: close keeps the persisted endpoint number,
             // so a re-enable mounts under the same identity. delete would
             // free the number and renumber every device on the next enable.
-            await endpoint.close();
+            await this.topologyChangeHandler(() => endpoint.close());
           } else {
-            await endpoint.delete();
+            await this.topologyChangeHandler(() => endpoint.delete());
           }
         } catch (e) {
           this.log.warn(

--- a/packages/backend/src/services/bridges/bridge.ts
+++ b/packages/backend/src/services/bridges/bridge.ts
@@ -198,6 +198,15 @@ export class Bridge {
       this.endpointManager.root,
       this.serverOptions,
     );
+    this.endpointManager.setTopologyChangeHandler(async (change) => {
+      await this.server.act("plugin topology change", (agent) =>
+        agent.get(BasicInformationServer).increaseConfigurationVersion(change),
+      );
+      this.log.debugCtx("Matter topology configuration version increased", {
+        configurationVersion: this.server.stateOf(BasicInformationServer)
+          .configurationVersion,
+      });
+    });
     // rotation is opt-in on an aggregator bridge, one controller session
     // holds many devices
     this.sessions = new SessionSupervisor(


### PR DESCRIPTION
## Problem

The plugin API exposes installation and loading of third-party packages, but the runtime path is incomplete:

1. Node.js ESM cannot import an installed package directory directly, so a normal package with `main` fails before `onStart`.
2. Devices registered or removed after the Matter node starts do not update the root configuration version, so commissioned controllers may never discover the changed topology.
3. Plugin endpoints expose their device type as the product name, which produces generic controller labels instead of the plugin-provided device name.

Together these issues make an installed plugin appear supported in the UI while preventing it from behaving as a first-class runtime extension.

## Changes

- Resolve and import the package manifest `main` entry as a file URL.
- Reject entry points that escape the package directory or do not exist.
- Wrap dynamic plugin endpoint add, close, and delete operations with Matter's `increaseConfigurationVersion` transaction.
- Publish `PluginDevice.name` through `productName`, `productLabel`, and `nodeLabel`.
- Add focused coverage for package entry-point loading and traversal rejection.

## Scope

This PR changes only the generic third-party plugin runtime. It does not add a plugin, alter the built-in security behavior, or introduce a new installation mechanism.
